### PR TITLE
Fix furigana cutoff on Firefox

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -21,6 +21,13 @@
   font-weight: normal;
 }
 
+@supports (-moz-appearance:none) {
+  [lang="ja"],
+  [lang="ja"] * {
+    font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  }
+}
+
 @keyframes spin {
   100% {
     transform: rotate(360deg);


### PR DESCRIPTION
Nice tool. I noticed furigana in the `<rt>` tags are cut off on Firefox; this is fixed by changing the font-family to `Helvetica Neue` on my machine (macOS). I'm not sure if this is just an issue with how the default font renders on Firefox; you could find a more elegant solution but I figured I would put up a PR as the style is quite simple and copies existing styles.

The issue:
![Image](https://github.com/user-attachments/assets/d98884b9-914a-498e-b0e9-0a8f663170d5)