### PR TITLE
Improve SEO: path routing, meta tags, sitemap

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,8 +41,13 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Add SPA fallback
-        run: cp dist/browser/index.html dist/browser/404.html
+      - name: Add SPA fallback and route pages
+        run: |
+          cp dist/browser/index.html dist/browser/404.html
+          for route in home information review summary; do
+            mkdir -p "dist/browser/$route"
+            cp dist/browser/index.html "dist/browser/$route/index.html"
+          done
 
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request'

--- a/angular.json
+++ b/angular.json
@@ -38,7 +38,9 @@
                 "input": "src/assets",
                 "output": "assets"
               },
-              "src/manifest.webmanifest"
+              "src/manifest.webmanifest",
+              "src/robots.txt",
+              "src/sitemap.xml"
             ],
             "styles": [
               "src/global.scss",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -61,6 +61,11 @@ export class AppComponent {
   }
 
   initializeApp() {
+    // Redirect old hash URLs (e.g. /#/information) to their path equivalent
+    if (location.hash.startsWith('#/')) {
+      this.router.navigateByUrl(location.hash.substring(1), { replaceUrl: true });
+    }
+
     this.translate.addLangs(['en', 'nl', 'ja']);
 
     const browserLang = (navigator.language || 'en').split('-')[0];

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,6 +1,6 @@
 import { ApplicationConfig, isDevMode, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
-import { provideRouter, RouteReuseStrategy, withHashLocation } from '@angular/router';
+import { provideRouter, RouteReuseStrategy } from '@angular/router';
 import { provideServiceWorker } from '@angular/service-worker';
 import { provideIonicAngular, IonicRouteStrategy } from '@ionic/angular/standalone';
 import { provideTranslateService } from '@ngx-translate/core';
@@ -12,7 +12,7 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
-    provideRouter(routes, withHashLocation()),
+    provideRouter(routes),
     provideHttpClient(),
     provideIonicAngular({ mode: 'ios' }),
     { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -2,8 +2,24 @@ import { Routes } from '@angular/router';
 
 export const routes: Routes = [
   { path: '', redirectTo: 'home', pathMatch: 'full' },
-  { path: 'home', loadComponent: () => import('./home/home-page.component').then(m => m.HomePageComponent) },
-  { path: 'information', loadComponent: () => import('./information/information-page.component').then(m => m.InformationPageComponent) },
-  { path: 'review', loadComponent: () => import('./review/review-page.component').then(m => m.ReviewPageComponent) },
-  { path: 'summary', loadComponent: () => import('./summary/summary-page.component').then(m => m.SummaryPageComponent) },
+  {
+    path: 'home',
+    title: 'Katsu: practise Japanese conjugation - 活用',
+    loadComponent: () => import('./home/home-page.component').then(m => m.HomePageComponent),
+  },
+  {
+    path: 'information',
+    title: 'Information - Katsu',
+    loadComponent: () => import('./information/information-page.component').then(m => m.InformationPageComponent),
+  },
+  {
+    path: 'review',
+    title: 'Practice - Katsu',
+    loadComponent: () => import('./review/review-page.component').then(m => m.ReviewPageComponent),
+  },
+  {
+    path: 'summary',
+    title: 'Summary - Katsu',
+    loadComponent: () => import('./summary/summary-page.component').then(m => m.SummaryPageComponent),
+  },
 ];

--- a/src/app/home/home-page.component.html
+++ b/src/app/home/home-page.component.html
@@ -12,6 +12,7 @@
 </ion-header>
 
 <ion-content>
+  <h1 class="sr-only">Katsu: practise Japanese conjugation - 活用</h1>
   <ion-grid>
     <ion-row>
       <ion-col>

--- a/src/global.scss
+++ b/src/global.scss
@@ -14,6 +14,19 @@
   font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 
+// Visually hidden, but available to screen readers and crawlers
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 [lang='ja'],
 [lang='ja'] * {
   //font-family: 'YuKyokasho Yoko', sans-serif;

--- a/src/index.html
+++ b/src/index.html
@@ -7,8 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
   <meta name="application-name" content="Katsu"/>
   <meta name="author" content="Arthur Hoek">
-  <meta name="description" content="Katsu is a conjugation practise app for Japanese verbs and adjectives."/>
-  <meta name="keywords" content="japanese, conjugation, verb, adjective, web app, practise"/>
+  <meta name="description" content="Katsu is a free practice app for Japanese verb and adjective conjugation. Drill the te-form, potential, passive, causative and more, from JLPT N5 to N1."/>
   <meta name="format-detection" content="telephone=no">
   <meta name="msapplication-tap-highlight" content="no">
   <meta name="apple-mobile-web-app-capable" content="yes">
@@ -17,6 +16,41 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black"/>
   <meta name="theme-color" content="#4e8ef7">
   <link rel="manifest" href="manifest.webmanifest">
+
+  <link rel="canonical" href="https://katsu.arthurhoek.nl/">
+
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Katsu">
+  <meta property="og:title" content="Katsu: practise Japanese conjugation - 活用">
+  <meta property="og:description" content="Free practice app for Japanese verb and adjective conjugation, from JLPT N5 to N1.">
+  <meta property="og:url" content="https://katsu.arthurhoek.nl/">
+  <meta property="og:image" content="https://katsu.arthurhoek.nl/assets/icon/largetile.png">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Katsu: practise Japanese conjugation - 活用">
+  <meta name="twitter:description" content="Free practice app for Japanese verb and adjective conjugation, from JLPT N5 to N1.">
+  <meta name="twitter:image" content="https://katsu.arthurhoek.nl/assets/icon/largetile.png">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    "name": "Katsu",
+    "alternateName": "活用",
+    "url": "https://katsu.arthurhoek.nl/",
+    "description": "Practice app for Japanese verb and adjective conjugation, from JLPT N5 to N1.",
+    "applicationCategory": "EducationalApplication",
+    "operatingSystem": "Any",
+    "offers": {
+      "@type": "Offer",
+      "price": "0"
+    },
+    "author": {
+      "@type": "Person",
+      "name": "Arthur Hoek"
+    },
+    "inLanguage": ["en", "nl"]
+  }
+  </script>
 
   <link rel="shortcut icon" href="assets/icon/favicon.ico" type="image/x-icon"/>
   <link rel="apple-touch-icon" sizes="57x57" href="assets/icon/apple-touch-icon-57x57.png">
@@ -36,7 +70,7 @@
   <meta name="msapplication-square150x150logo" content="assets/icon/mediumtile.png"/>
   <meta name="msapplication-wide310x150logo" content="assets/icon/widetile.png"/>
   <meta name="msapplication-square310x310logo" content="assets/icon/largetile.png"/>
-  <base href="./"/>
+  <base href="/"/>
 </head>
 
 <body>

--- a/src/robots.txt
+++ b/src/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /
+Disallow: /review
+Disallow: /summary
+
+Sitemap: https://katsu.arthurhoek.nl/sitemap.xml

--- a/src/sitemap.xml
+++ b/src/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://katsu.arthurhoek.nl/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://katsu.arthurhoek.nl/information</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.5</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
SEO improvements:

- Real path routing instead of `#/` hash URLs, with a client-side redirect for old bookmarks. Each route gets its own `index.html` on Pages so deep links return HTTP 200 instead of 404.
- Canonical URL, Open Graph/Twitter preview tags, and JSON-LD structured data in `index.html`.
- Per-route document titles.
- `robots.txt` (excludes the transient `/review` and `/summary` states) and `sitemap.xml`.
- Hidden `h1` on the home page.

Verified locally: direct `/information` load, `#/information` → `/information` redirect, route titles, and the full practice flow.