### PR TITLE
Auto-reload when a new version is deployed

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
+import { provideServiceWorker } from '@angular/service-worker';
 import { provideIonicAngular } from '@ionic/angular/standalone';
 import { provideTranslateService } from '@ngx-translate/core';
 
@@ -14,6 +15,7 @@ describe('AppComponent', () => {
         provideRouter([]),
         provideIonicAngular(),
         provideTranslateService(),
+        provideServiceWorker('ngsw-worker.js', { enabled: false }),
       ],
     }).compileComponents();
   });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -35,6 +35,7 @@ import {
 } from 'ionicons/icons';
 
 import { AnalyticsService } from './shared/analytics.service';
+import { UpdateService } from './shared/update.service';
 
 @Component({
   selector: 'app-root',
@@ -47,8 +48,10 @@ export class AppComponent {
   private readonly router = inject(Router);
   private readonly title = inject(Title);
   private readonly doc = inject(DOCUMENT);
+  private readonly updates = inject(UpdateService);
 
   constructor() {
+    this.updates.start();
     addIcons({
       arrowBack, arrowForward, barcodeOutline, bonfireOutline, briefcaseOutline,
       chatboxEllipsesOutline, checkmarkCircle, closeCircle, codeDownloadOutline,

--- a/src/app/shared/update.service.ts
+++ b/src/app/shared/update.service.ts
@@ -1,0 +1,46 @@
+import { Injectable, inject } from '@angular/core';
+import { NavigationEnd, Router } from '@angular/router';
+import { SwUpdate } from '@angular/service-worker';
+import { filter } from 'rxjs';
+
+/**
+ * Reload the app as soon as the service worker has downloaded a new version,
+ * so users get updates on their first visit instead of the second.
+ */
+@Injectable({ providedIn: 'root' })
+export class UpdateService {
+  private readonly swUpdate = inject(SwUpdate);
+  private readonly router = inject(Router);
+
+  private updateReady = false;
+
+  start() {
+    if (!this.swUpdate.isEnabled) {
+      return;
+    }
+
+    this.swUpdate.versionUpdates
+      .pipe(filter(event => event.type === 'VERSION_READY'))
+      .subscribe(() => {
+        this.updateReady = true;
+        this.reloadWhenSafe();
+      });
+
+    // If a reload was deferred, retry after each navigation
+    this.router.events
+      .pipe(filter(event => event instanceof NavigationEnd))
+      .subscribe(() => {
+        if (this.updateReady) {
+          this.reloadWhenSafe();
+        }
+      });
+  }
+
+  private reloadWhenSafe() {
+    // Don't interrupt an active practice round
+    if (this.router.url.startsWith('/review')) {
+      return;
+    }
+    location.reload();
+  }
+}


### PR DESCRIPTION
The Angular service worker serves the cached version first and only activates a new deploy on the next reload, so users were always one visit behind. This adds an UpdateService that reloads as soon as the new version is downloaded, deferring the reload while a practice round is active so progress isn't lost.