### PR TITLE
Simplify home screen: preferences page, session summary, theme switch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Add SPA fallback and route pages
         run: |
           cp dist/browser/index.html dist/browser/404.html
-          for route in home information review summary; do
+          for route in home information preferences review summary; do
             mkdir -p "dist/browser/$route"
             cp dist/browser/index.html "dist/browser/$route/index.html"
           done

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -23,6 +23,7 @@ import {
   logInOutline,
   logoPaypal,
   megaphoneOutline,
+  moonOutline,
   playBackOutline,
   playForwardOutline,
   sadOutline,
@@ -36,6 +37,8 @@ import {
 } from 'ionicons/icons';
 
 import { AnalyticsService } from './shared/analytics.service';
+import { SettingsService } from './shared/settings.service';
+import { ThemeService } from './shared/theme.service';
 import { UpdateService } from './shared/update.service';
 
 @Component({
@@ -50,6 +53,8 @@ export class AppComponent {
   private readonly title = inject(Title);
   private readonly doc = inject(DOCUMENT);
   private readonly updates = inject(UpdateService);
+  private readonly settings = inject(SettingsService);
+  private readonly theme = inject(ThemeService);
 
   constructor() {
     this.updates.start();
@@ -57,7 +62,7 @@ export class AppComponent {
       arrowBack, arrowForward, barcodeOutline, bonfireOutline, briefcaseOutline,
       chatboxEllipsesOutline, checkmarkCircle, closeCircle, codeDownloadOutline,
       codeWorkingOutline, flagOutline, hammerOutline, happyOutline, heartOutline,
-      languageOutline, logInOutline, logoPaypal, megaphoneOutline, playBackOutline,
+      languageOutline, logInOutline, logoPaypal, megaphoneOutline, moonOutline, playBackOutline,
       playForwardOutline, sadOutline, settingsOutline, shirtOutline, shuffle,
       shuffleOutline, trendingUp, volumeHighOutline, walkOutline,
     });
@@ -69,6 +74,8 @@ export class AppComponent {
     if (location.hash.startsWith('#/')) {
       this.router.navigateByUrl(location.hash.substring(1), { replaceUrl: true });
     }
+
+    this.settings.userSettings().then(() => this.theme.apply(this.settings.theme));
 
     this.translate.addLangs(['en', 'nl', 'ja']);
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -26,6 +26,7 @@ import {
   playBackOutline,
   playForwardOutline,
   sadOutline,
+  settingsOutline,
   shirtOutline,
   shuffle,
   shuffleOutline,
@@ -57,8 +58,8 @@ export class AppComponent {
       chatboxEllipsesOutline, checkmarkCircle, closeCircle, codeDownloadOutline,
       codeWorkingOutline, flagOutline, hammerOutline, happyOutline, heartOutline,
       languageOutline, logInOutline, logoPaypal, megaphoneOutline, playBackOutline,
-      playForwardOutline, sadOutline, shirtOutline, shuffle, shuffleOutline,
-      trendingUp, volumeHighOutline, walkOutline,
+      playForwardOutline, sadOutline, settingsOutline, shirtOutline, shuffle,
+      shuffleOutline, trendingUp, volumeHighOutline, walkOutline,
     });
     this.initializeApp();
   }

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -8,6 +8,11 @@ export const routes: Routes = [
     loadComponent: () => import('./home/home-page.component').then(m => m.HomePageComponent),
   },
   {
+    path: 'preferences',
+    title: 'Options - Katsu',
+    loadComponent: () => import('./preferences/preferences-page.component').then(m => m.PreferencesPageComponent),
+  },
+  {
     path: 'information',
     title: 'Information - Katsu',
     loadComponent: () => import('./information/information-page.component').then(m => m.InformationPageComponent),

--- a/src/app/home/home-page.component.html
+++ b/src/app/home/home-page.component.html
@@ -7,6 +7,9 @@
       <ion-button routerLink="/information" routerDirection="forward">
         {{ 'setting.info'|translate }}
       </ion-button>
+      <ion-button routerLink="/preferences" routerDirection="forward" [attr.aria-label]="'preferences.title'|translate">
+        <ion-icon slot="icon-only" name="settings-outline"></ion-icon>
+      </ion-button>
     </ion-buttons>
   </ion-toolbar>
 </ion-header>
@@ -141,6 +144,21 @@
               {{'setting.part-of-speech.na-adjective'|translate}}
             </ion-checkbox>
           </ion-item>
+          <ion-item>
+            <ion-icon name="trending-up" slot="start"></ion-icon>
+            <ion-select
+              [(ngModel)]="settings.jlptLevel"
+              [label]="'setting.group-title.jlpt-level'|translate"
+              interface="action-sheet"
+              justify="space-between"
+            >
+              <ion-select-option value="n5">N5</ion-select-option>
+              <ion-select-option value="n4">N4</ion-select-option>
+              <ion-select-option value="n3">N3</ion-select-option>
+              <ion-select-option value="n2">N2</ion-select-option>
+              <ion-select-option value="n1">N1</ion-select-option>
+            </ion-select>
+          </ion-item>
         </ion-list>
       </ion-col>
       <ion-col>
@@ -207,112 +225,12 @@
           </ion-item>
         </ion-list>
       </ion-col>
-      <ion-col>
-        <ion-list>
-          <ion-list-header>
-            {{'setting.group-title.special-options'|translate}}
-          </ion-list-header>
-          <ion-item>
-            <ion-icon name="trending-up" slot="start"></ion-icon>
-            <ion-select
-              [(ngModel)]="settings.jlptLevel"
-              [label]="'setting.group-title.jlpt-level'|translate"
-              interface="action-sheet"
-              justify="space-between"
-            >
-              <ion-select-option value="n5">N5</ion-select-option>
-              <ion-select-option value="n4">N4</ion-select-option>
-              <ion-select-option value="n3">N3</ion-select-option>
-              <ion-select-option value="n2">N2</ion-select-option>
-              <ion-select-option value="n1">N1</ion-select-option>
-            </ion-select>
-          </ion-item>
-          <ion-item>
-            <span name="no-suru" slot="start">する</span>
-            <ion-checkbox
-              [(ngModel)]="settings.leaveOutSuru"
-              [disabled]="settings.verb === false"
-              justify="space-between"
-            >
-              {{'setting.special.no-suru'|translate}}
-            </ion-checkbox>
-          </ion-item>
-          <ion-item>
-            <ion-icon name="shuffle-outline" slot="start"></ion-icon>
-            <ion-checkbox [(ngModel)]="settings.reverse" justify="space-between">
-              <ion-label>
-                {{'setting.special.reverse'|translate}}
-                <ion-note>{{'setting.special.reverse-note'|translate}}</ion-note>
-              </ion-label>
-            </ion-checkbox>
-          </ion-item>
-          <ion-item>
-            <span slot="start">#</span>
-            <ion-select
-              [(ngModel)]="settings.amount"
-              [selectedText]="settings.amount"
-              [label]="'setting.special.amount'|translate"
-              interface="action-sheet"
-              justify="space-between"
-            >
-              <ion-select-option value="10">10</ion-select-option>
-              <ion-select-option value="20">20</ion-select-option>
-              <ion-select-option value="30">30</ion-select-option>
-              <ion-select-option value="40">40</ion-select-option>
-              <ion-select-option value="50">50</ion-select-option>
-            </ion-select>
-          </ion-item>
-          <ion-item>
-            <ion-icon name="language-outline" slot="start"></ion-icon>
-            <ion-select
-              [ngModel]="settings.language"
-              (ngModelChange)="setLanguage($event)"
-              [label]="'setting.special.language'|translate"
-              interface="action-sheet"
-              justify="space-between"
-            >
-              <ion-select-option value="en">English</ion-select-option>
-              <ion-select-option value="nl">Nederlands</ion-select-option>
-            </ion-select>
-          </ion-item>
-          <ion-item>
-            <ion-icon name="volume-high-outline" slot="start"></ion-icon>
-            <ion-select
-              [ngModel]="settings.voice"
-              (ngModelChange)="setVoice($event)"
-              [label]="'setting.special.voice'|translate"
-              interface="action-sheet"
-              justify="space-between"
-            >
-              <ion-select-option value="">
-                {{'setting.special.none'|translate}}
-              </ion-select-option>
-              @for (voice of speech.getVoices(); track voice.name) {
-                <ion-select-option [value]="voice.name">
-                  {{voice.name}}
-                </ion-select-option>
-              }
-            </ion-select>
-          </ion-item>
-          <ion-item>
-            <ion-icon name="barcode-outline" slot="start"></ion-icon>
-            <ion-checkbox [(ngModel)]="settings.showMeaning" justify="space-between">
-              {{'setting.special.show-meaning'|translate}}
-            </ion-checkbox>
-          </ion-item>
-          <ion-item>
-            <ion-icon name="code-working-outline" slot="start"></ion-icon>
-            <ion-checkbox [(ngModel)]="settings.noFurigana" justify="space-between">
-              {{'setting.special.no-furigana'|translate}}
-            </ion-checkbox>
-          </ion-item>
-        </ion-list>
-      </ion-col>
-    </ion-row>
+          </ion-row>
   </ion-grid>
 </ion-content>
 
 <ion-footer>
+  <p class="session-summary">{{ summary }}</p>
   <ion-button
     (click)="startReview()"
     expand="full"

--- a/src/app/home/home-page.component.scss
+++ b/src/app/home/home-page.component.scss
@@ -42,3 +42,12 @@ ion-item:hover {
   --background: var(--ion-color-primary-shade);
   margin: 0;
 }
+
+.session-summary {
+  margin: 0;
+  padding: 6px 16px;
+  text-align: center;
+  font-size: .8rem;
+  color: var(--ion-color-medium);
+  background: var(--ion-background-color);
+}

--- a/src/app/home/home-page.component.ts
+++ b/src/app/home/home-page.component.ts
@@ -68,6 +68,21 @@ export class HomePageComponent implements OnInit {
   settings = inject(SettingsService);
 
 
+  /**
+   * Session summary shown above the start button,
+   * e.g. "10 questions · N3 · 2 forms"
+   */
+  get summary(): string {
+    const s = this.settings;
+    const formCount = [
+      s.normal, s.teForm, s.volitional, s.taiForm, s.tariForm, s.potential,
+      s.imperative, s.conditional, s.passive, s.causative, s.causativePassive,
+    ].filter(Boolean).length;
+    const questions = this.translate.instant('home.summary.questions');
+    const forms = this.translate.instant(formCount === 1 ? 'home.summary.form' : 'home.summary.forms');
+    return `${s.amount} ${questions} · ${s.jlptLevel.toUpperCase()} · ${formCount} ${forms}`;
+  }
+
   async ngOnInit() {
     // Default settings
     await this.settings.userSettings();
@@ -92,10 +107,5 @@ export class HomePageComponent implements OnInit {
   setLanguage(language: string) {
     this.settings.language = language;
     this.translate.use(this.settings.language);
-  }
-
-  setVoice(name: string) {
-    this.settings.voice = name;
-    this.speech.setVoiceByName(name);
   }
 }

--- a/src/app/preferences/preferences-page.component.html
+++ b/src/app/preferences/preferences-page.component.html
@@ -10,6 +10,20 @@
 <ion-content>
   <ion-list>
     <ion-item>
+      <ion-icon name="moon-outline" slot="start"></ion-icon>
+      <ion-select
+        [ngModel]="settings.theme"
+        (ngModelChange)="setTheme($event)"
+        [label]="'setting.special.theme'|translate"
+        interface="action-sheet"
+        justify="space-between"
+      >
+        <ion-select-option value="auto">{{'setting.special.theme-auto'|translate}}</ion-select-option>
+        <ion-select-option value="light">{{'setting.special.theme-light'|translate}}</ion-select-option>
+        <ion-select-option value="dark">{{'setting.special.theme-dark'|translate}}</ion-select-option>
+      </ion-select>
+    </ion-item>
+    <ion-item>
       <ion-icon name="language-outline" slot="start"></ion-icon>
       <ion-select
         [ngModel]="settings.language"

--- a/src/app/preferences/preferences-page.component.html
+++ b/src/app/preferences/preferences-page.component.html
@@ -1,0 +1,106 @@
+<ion-header>
+  <ion-toolbar color="secondary">
+    <ion-buttons slot="start">
+      <ion-back-button defaultHref="/home"></ion-back-button>
+    </ion-buttons>
+    <ion-title>{{'preferences.title'|translate}}</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+  <ion-list>
+    <ion-item>
+      <ion-icon name="language-outline" slot="start"></ion-icon>
+      <ion-select
+        [ngModel]="settings.language"
+        (ngModelChange)="setLanguage($event)"
+        [label]="'setting.special.language'|translate"
+        interface="action-sheet"
+        justify="space-between"
+      >
+        <ion-select-option value="en">English</ion-select-option>
+        <ion-select-option value="nl">Nederlands</ion-select-option>
+      </ion-select>
+    </ion-item>
+    <ion-item>
+      <ion-icon name="volume-high-outline" slot="start"></ion-icon>
+      <ion-select
+        [ngModel]="settings.voice"
+        (ngModelChange)="setVoice($event)"
+        [label]="'setting.special.voice'|translate"
+        interface="action-sheet"
+        justify="space-between"
+      >
+        <ion-select-option value="">
+          {{'setting.special.none'|translate}}
+        </ion-select-option>
+        @for (voice of speech.getVoices(); track voice.name) {
+          <ion-select-option [value]="voice.name">
+            {{voice.name}}
+          </ion-select-option>
+        }
+      </ion-select>
+    </ion-item>
+    <ion-item>
+      <span slot="start">#</span>
+      <ion-select
+        [ngModel]="settings.amount"
+        (ngModelChange)="settings.amount = $event; store()"
+        [selectedText]="settings.amount"
+        [label]="'setting.special.amount'|translate"
+        interface="action-sheet"
+        justify="space-between"
+      >
+        <ion-select-option value="10">10</ion-select-option>
+        <ion-select-option value="20">20</ion-select-option>
+        <ion-select-option value="30">30</ion-select-option>
+        <ion-select-option value="40">40</ion-select-option>
+        <ion-select-option value="50">50</ion-select-option>
+      </ion-select>
+    </ion-item>
+    <ion-item>
+      <ion-icon name="barcode-outline" slot="start"></ion-icon>
+      <ion-checkbox
+        [(ngModel)]="settings.showMeaning"
+        (ngModelChange)="store()"
+        justify="space-between"
+      >
+        {{'setting.special.show-meaning'|translate}}
+      </ion-checkbox>
+    </ion-item>
+    <ion-item>
+      <ion-icon name="code-working-outline" slot="start"></ion-icon>
+      <ion-checkbox
+        [(ngModel)]="settings.noFurigana"
+        (ngModelChange)="store()"
+        justify="space-between"
+      >
+        {{'setting.special.no-furigana'|translate}}
+      </ion-checkbox>
+    </ion-item>
+    <ion-item>
+      <span name="no-suru" slot="start">する</span>
+      <ion-checkbox
+        [(ngModel)]="settings.leaveOutSuru"
+        (ngModelChange)="store()"
+        [disabled]="settings.verb === false"
+        justify="space-between"
+      >
+        {{'setting.special.no-suru'|translate}}
+      </ion-checkbox>
+    </ion-item>
+    <ion-item>
+      <ion-icon name="shuffle-outline" slot="start"></ion-icon>
+      <ion-checkbox
+        [(ngModel)]="settings.reverse"
+        (ngModelChange)="store()"
+        justify="space-between"
+      >
+        <ion-label>
+          {{'setting.special.reverse'|translate}}
+          <ion-note>{{'setting.special.reverse-note'|translate}}</ion-note>
+        </ion-label>
+      </ion-checkbox>
+    </ion-item>
+  </ion-list>
+</ion-content>

--- a/src/app/preferences/preferences-page.component.ts
+++ b/src/app/preferences/preferences-page.component.ts
@@ -1,0 +1,66 @@
+import { Component, inject } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import {
+  IonBackButton,
+  IonButtons,
+  IonCheckbox,
+  IonContent,
+  IonHeader,
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonNote,
+  IonSelect,
+  IonSelectOption,
+  IonTitle,
+  IonToolbar,
+} from '@ionic/angular/standalone';
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
+
+import { SettingsService } from '../shared/settings.service';
+import { SpeechService } from '../shared/speech.service';
+
+@Component({
+  selector: 'app-preferences',
+  templateUrl: './preferences-page.component.html',
+  imports: [
+    FormsModule,
+    IonBackButton,
+    IonButtons,
+    IonCheckbox,
+    IonContent,
+    IonHeader,
+    IonIcon,
+    IonItem,
+    IonLabel,
+    IonList,
+    IonNote,
+    IonSelect,
+    IonSelectOption,
+    IonTitle,
+    IonToolbar,
+    TranslatePipe,
+  ],
+})
+export class PreferencesPageComponent {
+  private readonly translate = inject(TranslateService);
+  speech = inject(SpeechService);
+  settings = inject(SettingsService);
+
+  store() {
+    this.settings.store();
+  }
+
+  setLanguage(language: string) {
+    this.settings.language = language;
+    this.translate.use(language);
+    this.store();
+  }
+
+  setVoice(name: string) {
+    this.settings.voice = name;
+    this.speech.setVoiceByName(name);
+    this.store();
+  }
+}

--- a/src/app/preferences/preferences-page.component.ts
+++ b/src/app/preferences/preferences-page.component.ts
@@ -20,6 +20,7 @@ import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 
 import { SettingsService } from '../shared/settings.service';
 import { SpeechService } from '../shared/speech.service';
+import { ThemePreference, ThemeService } from '../shared/theme.service';
 
 @Component({
   selector: 'app-preferences',
@@ -45,11 +46,18 @@ import { SpeechService } from '../shared/speech.service';
 })
 export class PreferencesPageComponent {
   private readonly translate = inject(TranslateService);
+  private readonly theme = inject(ThemeService);
   speech = inject(SpeechService);
   settings = inject(SettingsService);
 
   store() {
     this.settings.store();
+  }
+
+  setTheme(theme: ThemePreference) {
+    this.settings.theme = theme;
+    this.theme.apply(theme);
+    this.store();
   }
 
   setLanguage(language: string) {

--- a/src/app/shared/settings.service.ts
+++ b/src/app/shared/settings.service.ts
@@ -290,6 +290,14 @@ export class SettingsService {
     this._noFurigana = value;
   }
 
+  private _theme: 'auto' | 'light' | 'dark' = 'auto';
+  get theme() {
+    return this._theme;
+  }
+  set theme(value) {
+    this._theme = value;
+  }
+
   private readonly translate = inject(TranslateService);
 
   private readonly storage = new Storage();

--- a/src/app/shared/theme.service.ts
+++ b/src/app/shared/theme.service.ts
@@ -1,0 +1,18 @@
+import { DOCUMENT, Injectable, inject } from '@angular/core';
+
+export type ThemePreference = 'auto' | 'light' | 'dark';
+
+/**
+ * Applies the user's theme preference by toggling classes on <html>.
+ * With no class, the OS color scheme decides (see theme/variables.scss).
+ */
+@Injectable({ providedIn: 'root' })
+export class ThemeService {
+  private readonly doc = inject(DOCUMENT);
+
+  apply(theme: ThemePreference) {
+    const root = this.doc.documentElement;
+    root.classList.toggle('theme-dark', theme === 'dark');
+    root.classList.toggle('theme-light', theme === 'light');
+  }
+}

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -54,7 +54,11 @@
       "voice": "Voice",
       "none": "None",
       "show-meaning": "Show meaning",
-      "no-furigana": "No furigana"
+      "no-furigana": "No furigana",
+      "theme": "Theme",
+      "theme-auto": "Auto",
+      "theme-light": "Light",
+      "theme-dark": "Dark"
     }
   },
   "home": {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -58,7 +58,12 @@
     }
   },
   "home": {
-    "start": "Start reviews!"
+    "start": "Start reviews!",
+    "summary": {
+      "questions": "questions",
+      "form": "form",
+      "forms": "forms"
+    }
   },
   "review": {
     "stop": "Stop",
@@ -68,5 +73,8 @@
     "title": "Summary",
     "close": "Done",
     "text": "You answered {{correct}} out of {{total}} correctly"
+  },
+  "preferences": {
+    "title": "Options"
   }
 }

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -58,7 +58,12 @@
     }
   },
   "home": {
-    "start": "Begin met oefenen!"
+    "start": "Begin met oefenen!",
+    "summary": {
+      "questions": "vragen",
+      "form": "vorm",
+      "forms": "vormen"
+    }
   },
   "review": {
     "stop": "Stop",
@@ -68,5 +73,8 @@
     "title": "Samenvatting",
     "close": "Klaar",
     "text": "Je hebt {{correct}} van de {{total}} goed beantwoord"
+  },
+  "preferences": {
+    "title": "Opties"
   }
 }

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -54,7 +54,11 @@
       "voice": "Stem",
       "none": "Geen",
       "show-meaning": "Toon betekenis",
-      "no-furigana": "Geen furigana"
+      "no-furigana": "Geen furigana",
+      "theme": "Thema",
+      "theme-auto": "Automatisch",
+      "theme-light": "Licht",
+      "theme-dark": "Donker"
     }
   },
   "home": {

--- a/src/robots.txt
+++ b/src/robots.txt
@@ -2,5 +2,6 @@ User-agent: *
 Allow: /
 Disallow: /review
 Disallow: /summary
+Disallow: /preferences
 
 Sitemap: https://katsu.arthurhoek.nl/sitemap.xml

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -66,8 +66,9 @@
   --app-color-bg-light: #ededf0;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
+// Dark theme values, applied when the user forces dark mode or when
+// the OS prefers dark and the user has not forced light mode.
+@mixin dark-theme {
     --ion-border-color: var(--ion-color-dark-shade);
     --ion-background-color: var(--ion-color-dark);
     --ion-background-color-rgb: var(--ion-color-dark-rgb);
@@ -118,5 +119,14 @@
 
     --app-color-bg-dark: #131300;
     --app-color-bg-light: #152524;
+}
+
+html.theme-dark {
+  @include dark-theme;
+}
+
+@media (prefers-color-scheme: dark) {
+  html:not(.theme-light) {
+    @include dark-theme;
   }
 }


### PR DESCRIPTION
First steps of the home-screen simplification:

- **Preferences page** behind a gear icon: language, voice, question count, show meaning, furigana, leave out suru, and reverse move off the home screen (7 of its 28 controls). Changes are persisted immediately instead of only when starting a review.
- **Theme preference** on that page: auto (follow the OS, current behaviour), light, or dark — stored with the other settings and applied at startup.
- **Session summary** above the start button ("10 questions · N3 · 2 forms") so the primary action says what it will do.
- JLPT level joins the word-type list; the special-options column is gone.

Verified in the browser: preferences round-trip to storage on change, theme override applies instantly and survives reload, summary updates live (including singular/plural), and the practice flow is unchanged.