### PR TITLE
Fix stale translations during SW updates, constrain content width

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@ionic/angular": "^8.8.14",
         "@ionic/storage": "^4.0.0",
         "@ngx-translate/core": "^18.0.0",
-        "@ngx-translate/http-loader": "^18.0.0",
         "gsap": "^3.15.0",
         "ionicons": "^8.0.13",
         "rxjs": "^7.8.2",
@@ -2947,20 +2946,6 @@
         "@angular/common": ">=18",
         "@angular/core": ">=18",
         "rxjs": ">=7"
-      }
-    },
-    "node_modules/@ngx-translate/http-loader": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@ngx-translate/http-loader/-/http-loader-18.0.0.tgz",
-      "integrity": "sha512-p6QpNcU3rkCYjHbKVIadcYtml/Njpr0aLp8neJ4uJWQ4Xm9f09bIePhOjdjAFHupTptKqKrG1J2gSi3RSwgYeA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "@angular/common": ">=18",
-        "@angular/core": ">=18",
-        "@ngx-translate/core": ">=18.0.0"
       }
     },
     "node_modules/@npmcli/agent": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@ionic/angular": "^8.8.14",
     "@ionic/storage": "^4.0.0",
     "@ngx-translate/core": "^18.0.0",
-    "@ngx-translate/http-loader": "^18.0.0",
     "gsap": "^3.15.0",
     "ionicons": "^8.0.13",
     "rxjs": "^7.8.2",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -36,6 +36,9 @@ import {
   walkOutline,
 } from 'ionicons/icons';
 
+import en from '../assets/i18n/en.json';
+import nl from '../assets/i18n/nl.json';
+
 import { AnalyticsService } from './shared/analytics.service';
 import { SettingsService } from './shared/settings.service';
 import { ThemeService } from './shared/theme.service';
@@ -77,6 +80,10 @@ export class AppComponent {
 
     this.settings.userSettings().then(() => this.theme.apply(this.settings.theme));
 
+    // Translations are bundled with the app so they can never be stale
+    // relative to the code (e.g. a service worker mid-update).
+    this.translate.setTranslation('en', en);
+    this.translate.setTranslation('nl', nl);
     this.translate.addLangs(['en', 'nl', 'ja']);
 
     const browserLang = (navigator.language || 'en').split('-')[0];

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -4,7 +4,6 @@ import { provideRouter, RouteReuseStrategy } from '@angular/router';
 import { provideServiceWorker } from '@angular/service-worker';
 import { provideIonicAngular, IonicRouteStrategy } from '@ionic/angular/standalone';
 import { provideTranslateService } from '@ngx-translate/core';
-import { provideTranslateHttpLoader } from '@ngx-translate/http-loader';
 
 import { routes } from './app.routes';
 
@@ -18,10 +17,6 @@ export const appConfig: ApplicationConfig = {
     { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
     provideTranslateService({
       fallbackLang: 'en',
-      loader: provideTranslateHttpLoader({
-        prefix: 'assets/i18n/',
-        suffix: '.json',
-      }),
     }),
     provideServiceWorker('ngsw-worker.js', { enabled: !isDevMode() }),
   ],

--- a/src/app/home/home-page.component.scss
+++ b/src/app/home/home-page.component.scss
@@ -43,11 +43,16 @@ ion-item:hover {
   margin: 0;
 }
 
+ion-grid {
+  max-width: 1024px;
+  margin: 0 auto;
+}
+
 .session-summary {
   margin: 0;
   padding: 6px 16px;
   text-align: center;
   font-size: .8rem;
   color: var(--ion-color-medium);
-  background: var(--ion-background-color);
+  background: var(--ion-background-color, #fff);
 }

--- a/src/app/preferences/preferences-page.component.scss
+++ b/src/app/preferences/preferences-page.component.scss
@@ -1,0 +1,4 @@
+ion-list {
+  max-width: 640px;
+  margin: 0 auto;
+}

--- a/src/app/preferences/preferences-page.component.ts
+++ b/src/app/preferences/preferences-page.component.ts
@@ -25,6 +25,7 @@ import { ThemePreference, ThemeService } from '../shared/theme.service';
 @Component({
   selector: 'app-preferences',
   templateUrl: './preferences-page.component.html',
+  styleUrls: ['./preferences-page.component.scss'],
   imports: [
     FormsModule,
     IonBackButton,

--- a/src/app/shared/settings.service.ts
+++ b/src/app/shared/settings.service.ts
@@ -257,10 +257,9 @@ export class SettingsService {
 
   private _language?: string;
   get language() {
-    if (this._language === undefined) {
-      this._language = this.translate.getCurrentLang() ?? 'en';
-    }
-    return this._language;
+    // Fall back to the active language without persisting it: only an
+    // explicit choice (the preferences page) should be stored.
+    return this._language ?? this.translate.getCurrentLang() ?? 'en';
   }
   set language(value) {
     this._language = value;

--- a/src/app/summary/summary-page.component.scss
+++ b/src/app/summary/summary-page.component.scss
@@ -32,3 +32,8 @@ ion-item {
     cursor: pointer;
   }
 }
+
+ion-list {
+  max-width: 800px;
+  margin: 0 auto;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "noFallthroughCasesInSwitch": true,
     "skipLibCheck": true,
     "isolatedModules": true,
+    "resolveJsonModule": true,
     "experimentalDecorators": true,
     "importHelpers": true,
     "target": "ES2022",


### PR DESCRIPTION
Two fixes:

- **Bundle translations with the app.** The service worker could serve a page mixing new app code with an old cached i18n JSON while an update was in flight, showing raw translation keys (seen live after the last deploy). The files are tiny, so they're now imported into the bundle and registered synchronously — translations are version-locked with the code, and `@ngx-translate/http-loader` is removed. Also fixes the language getter persisting its `'en'` fallback when read too early, which permanently overrode the browser language.
- **Constrain content width on large screens.** Home grid capped at 1024px, preferences/summary lists at 640/800px. Includes a light-mode fix for the session summary strip, which rendered black because `--ion-background-color` is only defined by the dark theme.