### PR TITLE
Endless review, clearer summary, and answer validation

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -5,6 +5,7 @@ import { IonApp, IonRouterOutlet } from '@ionic/angular/standalone';
 import { TranslateService } from '@ngx-translate/core';
 import { addIcons } from 'ionicons';
 import {
+  alertCircle,
   arrowBack,
   arrowForward,
   barcodeOutline,
@@ -63,7 +64,7 @@ export class AppComponent {
   constructor() {
     this.updates.start();
     addIcons({
-      arrowBack, arrowForward, barcodeOutline, bonfireOutline, briefcaseOutline,
+      alertCircle, arrowBack, arrowForward, barcodeOutline, bonfireOutline, briefcaseOutline,
       chatboxEllipsesOutline, checkmarkCircle, closeCircle, codeDownloadOutline,
       codeWorkingOutline, flagOutline, hammerOutline, happyOutline, heartOutline,
       helpCircleOutline, languageOutline, logInOutline, logoPaypal, megaphoneOutline, moonOutline, playBackOutline,

--- a/src/app/home/home-page.component.ts
+++ b/src/app/home/home-page.component.ts
@@ -69,8 +69,7 @@ export class HomePageComponent implements OnInit {
 
 
   /**
-   * Session summary shown above the start button,
-   * e.g. "10 questions · N3 · 2 forms"
+   * Session summary shown above the start button, e.g. "N3 · 2 forms"
    */
   get summary(): string {
     const s = this.settings;
@@ -78,9 +77,8 @@ export class HomePageComponent implements OnInit {
       s.normal, s.teForm, s.volitional, s.taiForm, s.tariForm, s.potential,
       s.imperative, s.conditional, s.passive, s.causative, s.causativePassive,
     ].filter(Boolean).length;
-    const questions = this.translate.instant('home.summary.questions');
     const forms = this.translate.instant(formCount === 1 ? 'home.summary.form' : 'home.summary.forms');
-    return `${s.amount} ${questions} · ${s.jlptLevel.toUpperCase()} · ${formCount} ${forms}`;
+    return `${s.jlptLevel.toUpperCase()} · ${formCount} ${forms}`;
   }
 
   async ngOnInit() {

--- a/src/app/models/question.ts
+++ b/src/app/models/question.ts
@@ -22,6 +22,9 @@ export class Question {
   public givenAnswer = '';
   public answered = false;
 
+  // The answer could not be read as Japanese (e.g. leftover latin letters)
+  public invalid = false;
+
   public reversed = false;
 
   static createFromVerb(verb: Verb): Question {
@@ -197,6 +200,7 @@ export class Question {
    */
   checkAnswer() {
     this.correct = false;
+    this.invalid = false;
     if (this.givenAnswer) {
       // Remove whitespace
       this.givenAnswer = this.givenAnswer.replace(/\s+/g, '');
@@ -210,9 +214,10 @@ export class Question {
     }
 
     // Check if given answer still contains romaji. If so, it was probably
-    // a typo.
+    // a typo and cannot be a valid Japanese answer.
     if (this.givenAnswer.match(/\w/)) {
       this.answered = false;
+      this.invalid = true;
       delete this.correct;
       return;
     }

--- a/src/app/preferences/preferences-page.component.html
+++ b/src/app/preferences/preferences-page.component.html
@@ -56,23 +56,6 @@
       </ion-select>
     </ion-item>
     <ion-item>
-      <span slot="start">#</span>
-      <ion-select
-        [ngModel]="settings.amount"
-        (ngModelChange)="settings.amount = $event; store()"
-        [selectedText]="settings.amount"
-        [label]="'setting.special.amount'|translate"
-        interface="action-sheet"
-        justify="space-between"
-      >
-        <ion-select-option value="10">10</ion-select-option>
-        <ion-select-option value="20">20</ion-select-option>
-        <ion-select-option value="30">30</ion-select-option>
-        <ion-select-option value="40">40</ion-select-option>
-        <ion-select-option value="50">50</ion-select-option>
-      </ion-select>
-    </ion-item>
-    <ion-item>
       <ion-icon name="barcode-outline" slot="start"></ion-icon>
       <ion-checkbox
         [(ngModel)]="settings.showMeaning"

--- a/src/app/review/question-data.service.ts
+++ b/src/app/review/question-data.service.ts
@@ -21,28 +21,43 @@ export class QuestionDataService {
 
   readonly questions = signal<Question[]>([]);
 
+  // Working copy of the word lists, depleted as questions are generated,
+  // and the pristine copy used to refill it for an endless session.
+  private pool: Dictionary = {};
+  private pristine: Dictionary = {};
+  private options: string[] = [];
+
   get currentQuestion(): Question {
     return this.questions()[this.index()];
   }
 
   /**
-   * Provider of question data
-   *
-   * SettingsService to create the answers
+   * Load the word data and produce the first question. Questions are then
+   * generated on demand via next(), for an endless practice session.
    */
   async load(): Promise<Question[]> {
     await this.settings.userSettings();
 
     const url = 'assets/data/questions/words.json';
-    const options = this.settings.getQuestionTypeOptions();
+    this.options = this.settings.getQuestionTypeOptions();
+    this.pristine = await firstValueFrom(this.http.get<Dictionary>(url));
+    this.refillPool();
 
-    const dictionary = await firstValueFrom(this.http.get<Dictionary>(url));
-    const questions = this.getQuestionsFromDictionary(dictionary, options);
-    if (questions.length > 0) {
-      this.questions.set(questions);
-    }
+    const first = this.generateQuestion();
+    this.questions.set(first ? [first] : []);
     this.index.set(0);
-    return questions;
+    return this.questions();
+  }
+
+  /**
+   * Generate the next question and append it. There is always a next one.
+   */
+  next(): Question | undefined {
+    const question = this.generateQuestion();
+    if (question) {
+      this.questions.update(questions => [...questions, question]);
+    }
+    return question;
   }
 
   resetAnsweredStatus() {
@@ -58,26 +73,33 @@ export class QuestionDataService {
     }, 0);
   }
 
-  private getQuestionsFromDictionary(dictionary: Dictionary, options: string[]): Question[] {
-    const numberOfQuestions = this.settings.amount || 10;
-    const questions: Question[] = [];
-
-    if (options.length === 0) {
-      return questions;
+  // Restore the working pool from the pristine copy (arrays are copied so
+  // that depletion never mutates the original).
+  private refillPool() {
+    this.pool = {};
+    for (const key of Object.keys(this.pristine)) {
+      this.pool[key] = [...this.pristine[key]];
     }
-    while (questions.length < numberOfQuestions) {
+  }
+
+  private generateQuestion(): Question | undefined {
+    if (this.options.length === 0) {
+      return undefined;
+    }
+    // Most attempts fail the JLPT-level filter, so allow generous retries;
+    // when a word pool is exhausted, refill it and keep going.
+    for (let attempt = 0; attempt < 500; attempt++) {
+      const questionType: string = this.getRandomItem(this.options, false);
       try {
-        const questionType: string = this.getRandomItem(options, false);
-        const question = this.getQuestion(dictionary, questionType);
+        const question = this.getQuestion(this.pool, questionType);
         if (question) {
-          questions.push(question);
+          return question;
         }
-      } catch (e) {
-        console.warn(e);
-        break;
+      } catch {
+        this.refillPool();
       }
     }
-    return questions;
+    return undefined;
   }
 
   /**

--- a/src/app/review/review-page.component.html
+++ b/src/app/review/review-page.component.html
@@ -8,7 +8,7 @@
     </ion-buttons>
 
     <ion-title>
-      {{index + 1}}
+      {{'summary.question'|translate}} {{index + 1}}
     </ion-title>
 
     <ion-buttons slot="end">

--- a/src/app/review/review-page.component.html
+++ b/src/app/review/review-page.component.html
@@ -75,6 +75,7 @@
               #answerInputNative
               lang="ja"
               [(ngModel)]="questions[index].givenAnswer"
+              (ngModelChange)="onAnswerChange()"
               [ngModelOptions]="{standalone: true}"
               class="answer-input native-input sc-ion-input-ios"
               type="text"
@@ -97,6 +98,12 @@
 
         <!-- Answer feedback, also announced to screen readers -->
         <div aria-live="polite">
+          @if (questions[index]?.invalid) {
+            <p class="feedback feedback--invalid">
+              <ion-icon name="alert-circle" aria-hidden="true"></ion-icon>
+              {{'review.invalid'|translate}}
+            </p>
+          }
           @if (questions[index]?.correct === true) {
             <p class="feedback feedback--correct">
               <ion-icon name="checkmark-circle" aria-hidden="true"></ion-icon>

--- a/src/app/review/review-page.component.html
+++ b/src/app/review/review-page.component.html
@@ -8,7 +8,7 @@
     </ion-buttons>
 
     <ion-title>
-      {{index + 1}} / {{questions.length}}
+      {{index + 1}}
     </ion-title>
 
     <ion-buttons slot="end">
@@ -18,7 +18,6 @@
       </ion-button>
     </ion-buttons>
   </ion-toolbar>
-  <ion-progress-bar [value]="getProgress()"></ion-progress-bar>
 </ion-header>
 
 <ion-content [class]="classNames()" class="patterned">
@@ -38,11 +37,14 @@
           </button>
         </p>
         @if (exampleVisible && example; as ex) {
-          <p class="example" lang="ja">
-            <app-furigana [input]="ex.from"></app-furigana>
-            <ion-icon name="arrow-forward" aria-hidden="true"></ion-icon>
-            <app-furigana [input]="ex.to"></app-furigana>
-          </p>
+          <div class="example">
+            <p class="example__explanation">{{'review.example-explanation'|translate}}</p>
+            <p class="example__pair" lang="ja">
+              <app-furigana [input]="ex.from"></app-furigana>
+              <ion-icon name="arrow-forward" aria-hidden="true"></ion-icon>
+              <app-furigana [input]="ex.to"></app-furigana>
+            </p>
+          </div>
         }
         <ion-item class="dictionary">
           <app-furigana

--- a/src/app/review/review-page.component.scss
+++ b/src/app/review/review-page.component.scss
@@ -82,6 +82,17 @@
   }
 }
 
+.invalid {
+  .answer-item {
+    --background: var(--ion-color-warning);
+    --color: var(--ion-color-warning-contrast);
+  }
+
+  [type='submit'] {
+    color: var(--ion-color-warning-contrast);
+  }
+}
+
 .answer-form {
   position: relative;
 }
@@ -127,6 +138,10 @@
 
 .feedback--incorrect {
   color: var(--ion-color-danger);
+}
+
+.feedback--invalid {
+  color: var(--ion-color-warning-shade);
 }
 
 .question-prompt {

--- a/src/app/review/review-page.component.scss
+++ b/src/app/review/review-page.component.scss
@@ -62,34 +62,34 @@
 
 .correct {
   .answer-item {
-    --background: var(--ion-color-success);
-    --color: var(--ion-color-success-contrast);
+    --background: var(--app-answer-correct-background);
+    --color: var(--app-answer-correct-color);
   }
 
   [type='submit'] {
-    color: var(--ion-color-success-contrast);
+    color: var(--app-answer-correct-color);
   }
 }
 
 .incorrect {
   .answer-item {
-    --background: var(--ion-color-danger);
-    --color: var(--ion-color-danger-contrast);
+    --background: var(--app-answer-incorrect-background);
+    --color: var(--app-answer-incorrect-color);
   }
 
   [type='submit'] {
-    color: var(--ion-color-danger-contrast);
+    color: var(--app-answer-incorrect-color);
   }
 }
 
 .invalid {
   .answer-item {
-    --background: var(--ion-color-warning);
-    --color: var(--ion-color-warning-contrast);
+    --background: var(--app-answer-invalid-background);
+    --color: var(--app-answer-invalid-color);
   }
 
   [type='submit'] {
-    color: var(--ion-color-warning-contrast);
+    color: var(--app-answer-invalid-color);
   }
 }
 

--- a/src/app/review/review-page.component.scss
+++ b/src/app/review/review-page.component.scss
@@ -150,14 +150,24 @@
 }
 
 .example {
-  display: flex;
-  align-items: center;
-  gap: 8px;
   margin: 4px 16px 8px;
-  font-size: 1.1rem;
 
-  ion-icon {
+  &__explanation {
+    margin: 0 0 4px;
+    font-size: .9rem;
     color: var(--ion-color-medium);
-    flex-shrink: 0;
+  }
+
+  &__pair {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0;
+    font-size: 1.1rem;
+
+    ion-icon {
+      color: var(--ion-color-medium);
+      flex-shrink: 0;
+    }
   }
 }

--- a/src/app/review/review-page.component.ts
+++ b/src/app/review/review-page.component.ts
@@ -10,7 +10,6 @@ import {
   IonIcon,
   IonItem,
   IonNote,
-  IonProgressBar,
   IonRow,
   IonTitle,
   IonToolbar,
@@ -64,7 +63,6 @@ const EXAMPLE_WORDS: Record<string, JishoDefinition> = {
     IonIcon,
     IonItem,
     IonNote,
-    IonProgressBar,
     IonRow,
     IonTitle,
     IonToolbar,
@@ -184,18 +182,13 @@ export class ReviewPageComponent implements OnInit, AfterViewInit {
     return this.settings.reverse ? { from: to, to: from } : { from, to };
   }
 
-  getProgress(): number {
-    if (this.questions.length === 0) {
-      return 0;
-    }
-    return this.index / this.questions.length;
-  }
-
   nextQuestion() {
     if (this.index < this.questions.length - 1) {
+      // Came back from the summary to an earlier question
       this.goToQuestion(this.index + 1);
-    } else {
-      this.showSummary();
+    } else if (this.dataService.next()) {
+      // Endless: generate a fresh question and move to it
+      this.goToQuestion(this.index + 1);
     }
   }
 

--- a/src/app/review/review-page.component.ts
+++ b/src/app/review/review-page.component.ts
@@ -211,8 +211,21 @@ export class ReviewPageComponent implements OnInit, AfterViewInit {
    * If correct, give good styling.
    * If incorrect, give 'bad' styling and show the correct answer.
    */
+  // Clear the invalid-input warning as soon as the answer is edited
+  onAnswerChange() {
+    const question = this.questions[this.index];
+    if (question?.invalid) {
+      question.invalid = false;
+    }
+  }
+
   checkAnswer(question: Question) {
     question.checkAnswer();
+
+    // The answer could not be read as Japanese: show an error and wait.
+    if (question.invalid) {
+      return;
+    }
 
     // If an answer is already given, go to the next question directly.
     if (question.answered === true) {
@@ -239,7 +252,8 @@ export class ReviewPageComponent implements OnInit, AfterViewInit {
     }
     return {
       correct: this.questions[this.index].correct === true,
-      incorrect: this.questions[this.index].correct === false
+      incorrect: this.questions[this.index].correct === false,
+      invalid: this.questions[this.index].invalid === true
     };
   }
 

--- a/src/app/shared/settings.service.ts
+++ b/src/app/shared/settings.service.ts
@@ -247,14 +247,6 @@ export class SettingsService {
   set reverse(value) {
     this._reverse = value;
   }
-  private _amount = 10;
-  get amount() {
-    return this._amount;
-  }
-  set amount(value) {
-    this._amount = value;
-  }
-
   private _language?: string;
   get language() {
     // Fall back to the active language without persisting it: only an

--- a/src/app/summary/summary-page.component.html
+++ b/src/app/summary/summary-page.component.html
@@ -22,11 +22,13 @@
         [class.incorrect]="item.question.correct === false"
       >
         <ion-label class="ion-text-wrap">
-          <span class="number">{{$index + 1}}</span>
+          <p class="question-title">{{'summary.question'|translate}} {{$index + 1}}</p>
 
-          <span class="given-answer" lang="ja">
-            {{item.question.givenAnswer}}
-          </span>
+          @if (item.question.givenAnswer) {
+            <p class="given-answer" lang="ja">{{item.question.givenAnswer}}</p>
+          } @else {
+            <p class="given-answer given-answer--skipped">{{'summary.skipped'|translate}}</p>
+          }
           <app-answers [question]="item.question"></app-answers>
         </ion-label>
 

--- a/src/app/summary/summary-page.component.html
+++ b/src/app/summary/summary-page.component.html
@@ -15,28 +15,28 @@
 <ion-content>
   <ion-list>
     <ion-item>{{ summaryText }}</ion-item>
-    @for (question of questions; track $index) {
+    @for (item of items; track $index) {
       <ion-item
-        (click)="goToQuestion($index)"
-        [class.correct]="question.correct === true"
-        [class.incorrect]="question.correct === false"
+        (click)="goToQuestion(item.index)"
+        [class.correct]="item.question.correct === true"
+        [class.incorrect]="item.question.correct === false"
       >
         <ion-label class="ion-text-wrap">
           <span class="number">{{$index + 1}}</span>
 
           <span class="given-answer" lang="ja">
-            {{question.givenAnswer}}
+            {{item.question.givenAnswer}}
           </span>
-          <app-answers [question]="question"></app-answers>
+          <app-answers [question]="item.question"></app-answers>
         </ion-label>
 
-        @if (question.correct === true) {
+        @if (item.question.correct === true) {
           <ion-icon
             name="checkmark-circle"
             color="success"
             slot="end"></ion-icon>
         }
-        @if (question.correct === false) {
+        @if (item.question.correct === false) {
           <ion-icon
             name="close-circle"
             color="danger"

--- a/src/app/summary/summary-page.component.scss
+++ b/src/app/summary/summary-page.component.scss
@@ -1,18 +1,25 @@
 ion-item {
   font-size: 1.6rem;
-}
 
-.number {
-  color: #666;
-
-  &::after {
-    content: '.';
+  &:hover {
+    cursor: pointer;
   }
 }
 
-.summary {
-  overflow-y: scroll;
-  display: block;
+.question-title {
+  margin: 0 0 4px;
+  font-size: .8rem;
+  color: var(--ion-color-medium);
+}
+
+.given-answer {
+  margin: 0;
+}
+
+.given-answer--skipped {
+  font-size: 1rem;
+  font-style: italic;
+  color: var(--ion-color-medium);
 }
 
 .correct .given-answer {
@@ -25,12 +32,6 @@ ion-item {
 
 answers ion-list.list-ios {
   margin-bottom: 0;
-}
-
-ion-item {
-  &:hover {
-    cursor: pointer;
-  }
 }
 
 ion-list {

--- a/src/app/summary/summary-page.component.ts
+++ b/src/app/summary/summary-page.component.ts
@@ -54,17 +54,25 @@ export class SummaryPageComponent {
   summaryText = '';
 
   constructor() {
-    this.items = this.questionService.questions()
-      .map((question, index) => ({ question, index }))
-      .filter(item => item.question.correct !== undefined);
+    const all = this.questionService.questions();
+    // Drop the final question if it was never answered — that is the one
+    // on screen when the user tapped Stop. Earlier empty ones were skipped
+    // on purpose and stay in the list.
+    const lastUnanswered = all.length > 0
+      && !all[all.length - 1].givenAnswer
+      && all[all.length - 1].correct === undefined;
+    const shown = lastUnanswered ? all.slice(0, -1) : all;
+    this.items = shown.map((question, index) => ({ question, index }));
     this.questionService.resetAnsweredStatus();
     this.setSummaryText();
   }
 
   setSummaryText() {
+    const answered = this.items.filter(item => item.question.givenAnswer);
+    const correct = answered.filter(item => item.question.correct === true).length;
     this.summaryText = this.translate.instant('summary.text', {
-      correct: this.questionService.getTotalCorrect(),
-      total: this.items.length,
+      correct,
+      total: answered.length,
     }) as string;
   }
 

--- a/src/app/summary/summary-page.component.ts
+++ b/src/app/summary/summary-page.component.ts
@@ -47,12 +47,16 @@ export class SummaryPageComponent {
   private readonly translate = inject(TranslateService);
 
 
-  questions: Question[];
+  // Answered questions with their original index, so the summary can skip
+  // unanswered/skipped questions yet still navigate back to the right one.
+  items: { question: Question; index: number }[];
 
   summaryText = '';
 
   constructor() {
-    this.questions = this.questionService.questions();
+    this.items = this.questionService.questions()
+      .map((question, index) => ({ question, index }))
+      .filter(item => item.question.correct !== undefined);
     this.questionService.resetAnsweredStatus();
     this.setSummaryText();
   }
@@ -60,7 +64,7 @@ export class SummaryPageComponent {
   setSummaryText() {
     this.summaryText = this.translate.instant('summary.text', {
       correct: this.questionService.getTotalCorrect(),
-      total: this.questions.length,
+      total: this.items.length,
     }) as string;
   }
 

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -49,7 +49,6 @@
       "reverse": "Reverse",
       "reverse-note": "(answer with dictionary form)",
       "no-suru": "Leave out ‘suru’ verbs",
-      "amount": "Amount of reviews",
       "language": "Language",
       "voice": "Voice",
       "none": "None",
@@ -64,7 +63,6 @@
   "home": {
     "start": "Start reviews!",
     "summary": {
-      "questions": "questions",
       "form": "form",
       "forms": "forms"
     }
@@ -76,7 +74,8 @@
     "incorrect": "Incorrect. The correct answer:",
     "prompt": "Give this form: {{terms}}",
     "prompt-reverse": "Give the dictionary form:",
-    "example": "Example"
+    "example": "Example",
+    "example-explanation": "Conjugate the word like this example:"
   },
   "summary": {
     "title": "Summary",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -80,7 +80,9 @@
   "summary": {
     "title": "Summary",
     "close": "Done",
-    "text": "You answered {{correct}} out of {{total}} correctly"
+    "text": "You answered {{correct}} out of {{total}} correctly",
+    "question": "Question",
+    "skipped": "Skipped"
   },
   "preferences": {
     "title": "Options"

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -75,7 +75,8 @@
     "prompt": "Give this form: {{terms}}",
     "prompt-reverse": "Give the dictionary form:",
     "example": "Example",
-    "example-explanation": "Conjugate the word like this example:"
+    "example-explanation": "Conjugate the word like this example:",
+    "invalid": "Please answer in Japanese (hiragana, katakana or kanji)."
   },
   "summary": {
     "title": "Summary",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -75,7 +75,8 @@
     "prompt": "Geef de vorm: {{terms}}",
     "prompt-reverse": "Geef de woordenboekvorm:",
     "example": "Voorbeeld",
-    "example-explanation": "Vervoeg het woord zoals in dit voorbeeld:"
+    "example-explanation": "Vervoeg het woord zoals in dit voorbeeld:",
+    "invalid": "Antwoord in het Japans (hiragana, katakana of kanji)."
   },
   "summary": {
     "title": "Samenvatting",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -80,7 +80,9 @@
   "summary": {
     "title": "Samenvatting",
     "close": "Klaar",
-    "text": "Je hebt {{correct}} van de {{total}} goed beantwoord"
+    "text": "Je hebt {{correct}} van de {{total}} goed beantwoord",
+    "question": "Vraag",
+    "skipped": "Overgeslagen"
   },
   "preferences": {
     "title": "Opties"

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -49,7 +49,6 @@
       "reverse": "Omgekeerd",
       "reverse-note": "(antwoord in woordenboekvorm)",
       "no-suru": "Laat ‘suru’ werkwoorden weg",
-      "amount": "Aantal vragen",
       "language": "Taal",
       "voice": "Stem",
       "none": "Geen",
@@ -64,7 +63,6 @@
   "home": {
     "start": "Begin met oefenen!",
     "summary": {
-      "questions": "vragen",
       "form": "vorm",
       "forms": "vormen"
     }
@@ -76,7 +74,8 @@
     "incorrect": "Helaas, het juiste antwoord:",
     "prompt": "Geef de vorm: {{terms}}",
     "prompt-reverse": "Geef de woordenboekvorm:",
-    "example": "Voorbeeld"
+    "example": "Voorbeeld",
+    "example-explanation": "Vervoeg het woord zoals in dit voorbeeld:"
   },
   "summary": {
     "title": "Samenvatting",

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -64,6 +64,15 @@
 
   --app-color-bg-dark: #ebebec;
   --app-color-bg-light: #ededf0;
+
+  // Answer field state colours. Light mode uses the bright brand colours;
+  // amber needs dark text for legibility.
+  --app-answer-correct-background: var(--ion-color-success);
+  --app-answer-correct-color: #fff;
+  --app-answer-incorrect-background: var(--ion-color-danger);
+  --app-answer-incorrect-color: #fff;
+  --app-answer-invalid-background: var(--ion-color-warning);
+  --app-answer-invalid-color: #000;
 }
 
 // Dark theme values, applied when the user forces dark mode or when
@@ -74,6 +83,15 @@
     --ion-background-color-rgb: var(--ion-color-dark-rgb);
     --ion-text-color: var(--ion-color-light);
     --ion-text-color-rgb: var(--ion-color-light-rgb);
+
+    // Darker, higher-contrast state colours so white text stays legible
+    // on the answer field in dark mode. color-mix keeps the brand hue.
+    --app-answer-correct-background: color-mix(in srgb, var(--ion-color-success), #000 62%);
+    --app-answer-correct-color: #fff;
+    --app-answer-incorrect-background: color-mix(in srgb, var(--ion-color-danger), #000 55%);
+    --app-answer-incorrect-color: #fff;
+    --app-answer-invalid-background: color-mix(in srgb, var(--ion-color-warning), #000 60%);
+    --app-answer-invalid-color: #fff;
 
     /* Ionic 8 step variables (bg steps go background -> text,
        text steps go text -> background) */


### PR DESCRIPTION
Review-page improvements.

- **Endless practice.** Questions are generated on demand and the session runs until the user taps Stop, instead of ending after a fixed count. The amount setting is removed; the header shows just the current question number.
- **Explained example.** The example popover now leads with a one-line instruction so it's clear what the from → to pair demonstrates.
- **Clearer summary.** The user's answer is shown on its own line, skipped questions appear labelled "Skipped", each entry is titled "Question n", and the score counts only answered questions.
- **Answer validation.** Submitting an answer that still contains latin characters (a romaji typo that couldn't convert to kana) now shows a warning and doesn't advance, instead of silently jumping to the next question. The warning clears as soon as the answer is edited. Fixes #47.
- **Dark-mode contrast.** The green/amber/red answer-field states use darker, derived fills in dark mode so white text stays legible; amber also gets dark text in light mode.

Verified in the browser across light and dark modes: endless flow, example, all answer states (correct/incorrect/invalid), and the summary.