### PR TITLE
Fix furigana being clipped in Firefox

### DIFF
--- a/src/app/components/answers/answers.component.scss
+++ b/src/app/components/answers/answers.component.scss
@@ -43,10 +43,6 @@
   }
 }
 
-ruby rt {
-  font-size: .6em;
-}
-
 .step-labels {
   color: var(--ion-color-medium);
 }

--- a/src/app/components/furigana/furigana.component.scss
+++ b/src/app/components/furigana/furigana.component.scss
@@ -1,0 +1,11 @@
+// Gecko draws furigana in the leading above the base instead of growing the
+// line box, so reserve that leading here: without it the annotation overhangs
+// the line and gets clipped by ancestors with overflow: hidden.
+ruby {
+  line-height: 2.4;
+}
+
+rt {
+  font-size: 50%;
+  line-height: 1.1;
+}

--- a/src/app/components/furigana/furigana.component.ts
+++ b/src/app/components/furigana/furigana.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, inject } from '@angular/core';
+import { Component, Input, ViewEncapsulation, inject } from '@angular/core';
 import * as wanakana from 'wanakana';
 
 import { WordToken } from '../../models/word-token';
@@ -7,6 +7,9 @@ import { SettingsService } from '../../shared/settings.service';
 @Component({
   selector: 'app-furigana',
   templateUrl: 'furigana.component.html',
+  styleUrls: ['furigana.component.scss'],
+  // The ruby markup is set with [innerHTML], so scoped styles never reach it.
+  encapsulation: ViewEncapsulation.None,
 })
 export class FuriganaComponent {
   settings = inject(SettingsService);

--- a/src/app/review/review-page.component.scss
+++ b/src/app/review/review-page.component.scss
@@ -11,10 +11,6 @@
 
   &__word {
     font-size: 2.1em;
-
-    rt {
-      font-size: 60%;
-    }
   }
 
   &__meaning {


### PR DESCRIPTION
Alternative to #46, which reported this. Thanks @mngyuan for the report and the screenshot.

## Cause

Gecko draws ruby annotations in the leading above the base text rather than growing the line box to fit them. Blink and WebKit grow the line box, which is why this only shows up in Firefox.

Measuring the review page, the annotation sat *exactly* on `ion-item`'s `overflow: hidden` edge — 0.0px of slack, even in Chromium. Firefox places it marginally higher, so it clips.

## Fix

Reserve that leading on the `ruby` element itself, so the annotation has somewhere to live in every engine:

```scss
ruby { line-height: 2.4; }
rt   { font-size: 50%; line-height: 1.1; }
```

The rt line box is 18.5px and `2.4` yields 23.6px of half-leading, so there is 5.1px of headroom. `2.2` gave only 1.7px, which is too thin to rely on across font metrics.

Slack at the clipping edge, measured in Chromium:

| | before | after |
|---|---|---|
| `ion-item.dictionary` | 0.0px | 6.5px |

This keeps the Japanese font stack in `global.scss` intact, and needs no engine sniffing.

## Trade-off

Ruby lines are taller: the dictionary item goes from 59.5px to ~78px, and ruby lines in the steps list sit looser than non-ruby ones, since leading is symmetric and the space below the base is unavoidable slack. `line-height` is the single knob, with a floor around `2.3`.