### PR TITLE
Keep the review question and answer field in view while answering

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -11,6 +11,7 @@ import {
   barcodeOutline,
   briefcaseOutline,
   checkmarkCircle,
+  chevronDown,
   close,
   closeCircle,
   codeWorkingOutline,
@@ -56,7 +57,7 @@ export class AppComponent {
     this.updates.start();
     addIcons({
       alertCircle, arrowBack, arrowForward, barcodeOutline, briefcaseOutline,
-      checkmarkCircle, close, closeCircle, codeWorkingOutline, helpCircleOutline,
+      checkmarkCircle, chevronDown, close, closeCircle, codeWorkingOutline, helpCircleOutline,
       languageOutline, logoGithub, logoPaypal, mailOutline, moonOutline, optionsOutline, playBackOutline,
       playForwardOutline, settingsOutline, shirtOutline, shuffleOutline,
       volumeHighOutline,

--- a/src/app/components/answers/answers.component.html
+++ b/src/app/components/answers/answers.component.html
@@ -8,7 +8,21 @@
   </div>
 
   @if (showExplanation && steps.length > 0) {
-    <ol class="correct-answer__steps">
+    <button
+      class="correct-answer__toggle"
+      type="button"
+      (click)="toggleExplanation()"
+      [attr.aria-expanded]="explanationVisible"
+      [attr.aria-controls]="stepsId"
+    >
+      {{ 'review.explanation' | translate }}
+      <ion-icon
+        class="correct-answer__chevron"
+        name="chevron-down"
+        aria-hidden="true"
+      ></ion-icon>
+    </button>
+    <ol class="correct-answer__steps" [id]="stepsId" [hidden]="!explanationVisible">
       @for (step of steps; track $index) {
         <li>
           @if (step.from && step.to) {

--- a/src/app/components/answers/answers.component.scss
+++ b/src/app/components/answers/answers.component.scss
@@ -27,11 +27,44 @@
   }
 }
 
+.correct-answer__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  // Comfortable tap target without making the collapsed block much taller
+  min-height: 44px;
+  padding: 0;
+  background: none;
+  border: none;
+  font-size: .95rem;
+  color: var(--app-color-link);
+  cursor: pointer;
+
+  &[aria-expanded='true'] .correct-answer__chevron {
+    transform: rotate(180deg);
+  }
+}
+
+.correct-answer__chevron {
+  font-size: 1.1rem;
+  transition: transform 150ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .correct-answer__chevron {
+    transition: none;
+  }
+}
+
 .correct-answer__steps {
   margin: 10px 0 2px;
   padding-left: 1.3em;
   font-size: 1.05rem;
   color: var(--ion-color-medium);
+
+  &[hidden] {
+    display: none;
+  }
 
   li {
     margin: 6px 0;

--- a/src/app/components/answers/answers.component.ts
+++ b/src/app/components/answers/answers.component.ts
@@ -1,8 +1,13 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { IonIcon } from '@ionic/angular/standalone';
 import { TranslatePipe } from '@ngx-translate/core';
 
 import { ExplanationStep, Question } from '../../models/question';
 import { FuriganaComponent } from '../furigana/furigana.component';
+
+// Unique ids so the disclosure button can point at its own steps list,
+// also on the summary, which renders many of these at once.
+let nextId = 0;
 
 /**
  * The correct answer(s) to a question, with rule-based steps explaining
@@ -12,15 +17,32 @@ import { FuriganaComponent } from '../furigana/furigana.component';
   selector: 'app-answers',
   templateUrl: './answers.component.html',
   styleUrls: ['./answers.component.scss'],
-  imports: [FuriganaComponent, TranslatePipe],
+  imports: [IonIcon, FuriganaComponent, TranslatePipe],
 })
-export class AnswersComponent {
+export class AnswersComponent implements OnChanges {
   @Input() question!: Question;
 
   /** Hide the grammar explanation (e.g. in compact listings) */
   @Input() showExplanation = true;
 
+  readonly stepsId = `answer-steps-${nextId++}`;
+
+  // Closed by default: it keeps the answer visible on a screen filled by the
+  // keyboard, and keeps the summary scannable.
+  explanationVisible = false;
+
   get steps(): ExplanationStep[] {
     return this.question.explanationSteps();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    // A new question starts closed again
+    if (changes['question']) {
+      this.explanationVisible = false;
+    }
+  }
+
+  toggleExplanation() {
+    this.explanationVisible = !this.explanationVisible;
   }
 }

--- a/src/app/review/review-page.component.html
+++ b/src/app/review/review-page.component.html
@@ -101,6 +101,7 @@
               slot="end"
               fill="clear"
               type="submit"
+              (mousedown)="keepKeyboardOpen($event)"
               [class.pulse]="questions[index]?.answered"
             >
               <ion-icon name="arrow-forward"></ion-icon>
@@ -118,33 +119,51 @@
           </div>
         </form>
 
-        <!-- Skip acts on the current question, so it lives with the answer -->
-        <div class="skip-row">
-          <ion-button fill="clear" size="small" color="medium" (click)="nextQuestion()">
-            {{'review.skip'|translate}}
-            <ion-icon slot="end" name="arrow-forward"></ion-icon>
-          </ion-button>
+        <!-- The verdict shares the row with Skip, which acts on the current
+             question, so it costs no vertical space on a screen filled by the
+             keyboard. Both live regions stay in the DOM, empty, so that screen
+             readers announce what appears in them. -->
+        <div class="status-row">
+          <div class="feedback-slot" aria-live="polite">
+            @if (questions[index]?.invalid) {
+              <p class="feedback feedback--invalid">
+                <ion-icon name="alert-circle" aria-hidden="true"></ion-icon>
+                {{'review.invalid'|translate}}
+              </p>
+            }
+            @if (questions[index]?.correct === true) {
+              <p class="feedback feedback--correct">
+                <ion-icon name="checkmark-circle" aria-hidden="true"></ion-icon>
+                {{'review.correct'|translate}}
+              </p>
+            }
+            @if (questions[index]?.correct === false) {
+              <p class="feedback feedback--incorrect">
+                <ion-icon name="close-circle" aria-hidden="true"></ion-icon>
+                {{'review.incorrect'|translate}}
+              </p>
+            }
+          </div>
+
+          <!-- Once answered, the arrow beside the answer moves on, so there is
+               nothing left to skip -->
+          @if (!questions[index]?.answered) {
+            <ion-button
+              class="skip-button"
+              fill="clear"
+              size="small"
+              color="medium"
+              (mousedown)="keepKeyboardOpen($event)"
+              (click)="nextQuestion()"
+            >
+              {{'review.skip'|translate}}
+              <ion-icon slot="end" name="arrow-forward"></ion-icon>
+            </ion-button>
+          }
         </div>
 
-        <!-- Answer feedback, also announced to screen readers -->
         <div aria-live="polite">
-          @if (questions[index]?.invalid) {
-            <p class="feedback feedback--invalid">
-              <ion-icon name="alert-circle" aria-hidden="true"></ion-icon>
-              {{'review.invalid'|translate}}
-            </p>
-          }
-          @if (questions[index]?.correct === true) {
-            <p class="feedback feedback--correct">
-              <ion-icon name="checkmark-circle" aria-hidden="true"></ion-icon>
-              {{'review.correct'|translate}}
-            </p>
-          }
           @if (questions[index]?.correct === false) {
-            <p class="feedback feedback--incorrect">
-              <ion-icon name="close-circle" aria-hidden="true"></ion-icon>
-              {{'review.incorrect'|translate}}
-            </p>
             <app-answers [question]="questions[index]"></app-answers>
           }
         </div>

--- a/src/app/review/review-page.component.scss
+++ b/src/app/review/review-page.component.scss
@@ -14,6 +14,11 @@ ion-col {
 
   &__word {
     font-size: 2.1em;
+    // One tall line that already fits the furigana, so the row keeps its
+    // height while the question loads and across words with and without kanji
+    display: inline-block;
+    line-height: 2.4;
+    min-height: 1lh;
   }
 
   &__meaning {
@@ -218,6 +223,11 @@ ion-col {
 .question-prompt {
   margin: 16px 16px 2px;
   font-size: .9rem;
+  // The longest question sentence wraps to two lines, so hold that space:
+  // the row below stays put while loading and between questions. The line
+  // box is taller than the help icon, so the first line never grows either.
+  line-height: 1.6;
+  min-height: 2lh;
   color: var(--ion-color-medium);
 }
 

--- a/src/app/review/review-page.component.scss
+++ b/src/app/review/review-page.component.scss
@@ -199,7 +199,7 @@ ion-col {
   display: flex;
   align-items: center;
   gap: 6px;
-  margin: 12px 16px 4px;
+  margin: 0 0 0 16px;
   font-size: 1rem;
 
   ion-icon {
@@ -301,12 +301,25 @@ ion-grid {
   max-width: 720px;
 }
 
-.skip-row {
+// The verdict sits left of Skip; the button's height carries the row, so a
+// verdict appearing never moves anything below it.
+.status-row {
   display: flex;
-  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
+  // Height of the Skip button, held so the row does not twitch when Skip
+  // gives way to the verdict
+  min-height: 35px;
   margin: 0 8px;
 
-  ion-button {
+  .feedback-slot {
+    min-width: 0;
+  }
+
+  .skip-button {
+    // Keep Skip on the right, with or without a verdict beside it
+    margin-left: auto;
+    flex-shrink: 0;
     --color: var(--ion-color-medium);
   }
 }

--- a/src/app/review/review-page.component.ts
+++ b/src/app/review/review-page.component.ts
@@ -139,6 +139,16 @@ export class ReviewPageComponent implements OnInit {
   }
 
   /**
+   * Tapping a button next to the answer field would move focus and close the
+   * on-screen keyboard, which resizes the viewport and scrolls the question
+   * out of view. Suppressing the pointer's focus keeps the field active;
+   * the button stays reachable by keyboard.
+   */
+  keepKeyboardOpen(event: Event) {
+    event.preventDefault();
+  }
+
+  /**
    * The question sentence, composed from the question type attributes
    * using the same terms as the settings screen.
    */

--- a/src/app/review/review-page.component.ts
+++ b/src/app/review/review-page.component.ts
@@ -270,13 +270,14 @@ export class ReviewPageComponent implements OnInit {
    */
   public currentQuestion(): { word: string; reading: string } {
     const question = this.questions[this.index];
-    if (!question) {
+    // No type means the placeholder question shown while loading
+    if (!question?.type) {
       return { word: '', reading: '' };
     }
 
     const na = this.getNa(question);
     return {
-      word: question.word + na,
+      word: (question.word ?? question.reading) + na,
       reading: question.reading + na,
     };
   }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -78,7 +78,8 @@
     "example": "Example",
     "example-explanation": "Conjugate the word like this example:",
     "invalid": "Please answer in Japanese (hiragana, katakana or kanji).",
-    "example-more": "More in the guide"
+    "example-more": "More in the guide",
+    "explanation": "Explanation"
   },
   "summary": {
     "title": "Summary",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -78,7 +78,8 @@
     "example": "Voorbeeld",
     "example-explanation": "Vervoeg het woord zoals in dit voorbeeld:",
     "invalid": "Antwoord in het Japans (hiragana, katakana of kanji).",
-    "example-more": "Meer in de uitleg"
+    "example-more": "Meer in de uitleg",
+    "explanation": "Uitleg"
   },
   "summary": {
     "title": "Samenvatting",


### PR DESCRIPTION
The review screen moved under the user in two ways: content jumped as the first question loaded, and on iOS the question and answer field scrolled out of view at the top right after answering — without the user scrolling.

## Layout held steady while loading

Two elements collapsed when empty. The word row lost 33px without a word and now sits in one tall line box that already fits the furigana, so it keeps its height when empty, kana-only, or kanji with ruby above it. The question sentence is one line when empty and two once the terms are in, so the card below moved 19px; it now reserves two lines, with the line box set taller than the help icon so the icon cannot inflate the first line and defeat the reservation. That also removes a shift between questions, since `Give this form: Te-form` takes one line where a long form list takes two.

Placeholder questions render blank instead of the literal string `undefined`, which appeared because the word was concatenated with the na-suffix before the data arrived. A reverse-mode kana-only word reaches the same path with no word set, so that is covered too.

## Fitting the answered state in the space the keyboard leaves

An answered question was 745px of content in roughly 420px of visible space. Safari re-derives the scroll position whenever the layout changes under a focused input, and again when the keyboard closes and reopens — but the overflow is what lets it move at all, so this removes the overflow instead of fighting the browser. The answered state is now 458px:

- The grammar explanation, 282px of the total, moves behind a disclosure button. It is reference material rather than something needed on every question, and it remains on the summary and in the guide.
- The verdict moves onto the row with Skip instead of claiming a line of its own. The row keeps the button's height, so a verdict appearing moves nothing below it.
- Skip disappears once the question is answered, where the arrow beside the field already moves on.
- The summary collapses the explanation as well, which fits two questions per phone screen where one used to.

Tapping the arrow or Skip no longer closes the keyboard: the pointer's focus default is suppressed, which keyboard activation never fires. This is deliberately **not** `tabindex="-1"`, which would hide a visible control from keyboard users.

## Accessibility

- The disclosure is a real `<button>` with `aria-expanded` and `aria-controls`; the steps stay in the DOM and are toggled with the `hidden` attribute so the id always resolves, and ids are per instance because the summary renders several at once. 44px tap target, `aria-hidden` chevron, rotation disabled under `prefers-reduced-motion`.
- Toggle label contrast is 8.1:1 dark / 6.6:1 light.
- The verdict and the correct answer keep separate live regions that stay in the DOM, so announcements are unchanged and "Skip" is never read out on answering. Collapsed steps are excluded from the accessible text.
- Both buttons keep `tabIndex` 0; Tab reaches them and a click with no preceding mousedown — what Enter or Space on a focused button produces — still submits.

## Verification

- Element positions measured across the empty placeholder, short and long question sentences, kana-only and kanji words, and the invalid, correct and incorrect states at 320/375/390/560/720px: the prompt, word card and answer field hold identical positions in every case.
- Worst-case scroll on an answered question is now 38px (was 325px), leaving the word card and field fully visible.
- Focus retention, keyboard-style activation, per-question collapse reset, and unique/resolving `aria-controls` ids on a populated summary all checked in the browser.
- `ng lint`, `ng build` and all 21 unit tests pass. The only build warning is the pre-existing unused `IonRouterLink` import in `CreditComponent`.

## Known limitations

- The iOS auto-scroll itself could not be reproduced locally; the geometry fix is verified, but suppressing focus on `mousedown` is the standard remedy for a tap dismissing the keyboard and deserves a check on a device. If Safari still blurs the field, the fallback is refocusing the input at the end of `checkAnswer`.
- The "answer in Japanese" validation message is much longer than the verdicts, so beside Skip it wraps to two lines at 390px and three at 320px. It only grows downward and moves nothing above it, so the copy was left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)