### PR TITLE
Lay the app out in the height the on-screen keyboard leaves

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -37,6 +37,7 @@ import { AnalyticsService } from './shared/analytics.service';
 import { SettingsService } from './shared/settings.service';
 import { ThemeService } from './shared/theme.service';
 import { UpdateService } from './shared/update.service';
+import { ViewportService } from './shared/viewport.service';
 
 @Component({
   selector: 'app-root',
@@ -52,9 +53,11 @@ export class AppComponent {
   private readonly updates = inject(UpdateService);
   private readonly settings = inject(SettingsService);
   private readonly theme = inject(ThemeService);
+  private readonly viewport = inject(ViewportService);
 
   constructor() {
     this.updates.start();
+    this.viewport.start();
     addIcons({
       alertCircle, arrowBack, arrowForward, barcodeOutline, briefcaseOutline,
       checkmarkCircle, chevronDown, close, closeCircle, codeWorkingOutline, helpCircleOutline,

--- a/src/app/review/review-page.component.scss
+++ b/src/app/review/review-page.component.scss
@@ -323,3 +323,22 @@ ion-grid {
     --color: var(--ion-color-medium);
   }
 }
+
+// With the keyboard up there is little more than 250px to work with, so the
+// gutters give way while the question and answer field keep their size. Only
+// margins: the line heights are what hold the reserved space, and the word row
+// is sized by its furigana, so shrinking either would let the layout shift
+// again while loading.
+:host-context(html.app-short-viewport) {
+  .question-prompt {
+    margin-top: 8px;
+  }
+
+  .dictionary {
+    margin-top: 8px;
+  }
+
+  .answer-item {
+    margin-top: 2px;
+  }
+}

--- a/src/app/shared/viewport.service.ts
+++ b/src/app/shared/viewport.service.ts
@@ -1,0 +1,36 @@
+import { DOCUMENT, Injectable, inject } from '@angular/core';
+
+// Under this height the review screen tightens its spacing; roughly what an
+// on-screen keyboard leaves of a phone screen.
+const SHORT_VIEWPORT = 480;
+
+/**
+ * Publishes the height that is actually visible, keyboard included.
+ *
+ * Safari does not implement `interactive-widget`, so its keyboard shrinks
+ * only the visual viewport: the layout keeps its full height, the lower part
+ * of it ends up behind the keyboard, and the browser scrolls the page to
+ * reveal the focused field. Sizing the app to the visible height instead
+ * leaves it nothing to scroll.
+ */
+@Injectable({ providedIn: 'root' })
+export class ViewportService {
+  private readonly doc = inject(DOCUMENT);
+
+  start() {
+    const viewport = this.doc.defaultView?.visualViewport;
+    if (!viewport) {
+      return;
+    }
+
+    const apply = () => {
+      const root = this.doc.documentElement;
+      const height = Math.round(viewport.height);
+      root.style.setProperty('--app-visible-height', `${height}px`);
+      root.classList.toggle('app-short-viewport', height < SHORT_VIEWPORT);
+    };
+
+    viewport.addEventListener('resize', apply);
+    apply();
+  }
+}

--- a/src/global.scss
+++ b/src/global.scss
@@ -20,6 +20,12 @@ ion-button {
   letter-spacing: normal;
 }
 
+// Lay the app out in the height the keyboard leaves (see ViewportService),
+// so the browser never has to scroll the page to reveal a focused field.
+ion-app {
+  height: var(--app-visible-height, 100%);
+}
+
 // Floating app chrome: a translucent, blurred strip over the canvas,
 // constrained to the same centred column as the content. Pages using it
 // set [fullscreen]="true" on ion-content so the canvas runs underneath.

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,9 @@
 <head>
   <meta charset="utf-8"/>
   <title>Katsu: practise Japanese conjugation - 活用</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
+  <!-- interactive-widget: let the keyboard resize the layout where it is
+       supported (Chrome, Firefox); Safari needs ViewportService for this -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0, interactive-widget=resizes-content">
   <meta name="application-name" content="Katsu"/>
   <meta name="author" content="Arthur Hoek">
   <meta name="description" content="Katsu is a free practice app for Japanese verb and adjective conjugation. Drill the te-form, potential, passive, causative and more, from JLPT N5 to N1."/>


### PR DESCRIPTION
Follow-up to #59. The remaining jump on iOS was not the app scrolling itself: Safari does not implement the viewport meta's `interactive-widget` ([WebKit bug 259770](https://bugs.webkit.org/show_bug.cgi?id=259770)), so its keyboard shrinks only the **visual** viewport. The layout keeps the full window height, its lower part ends up behind the keyboard, and when the answer field takes focus the browser scrolls the page to reveal it — the question slides up under the header, with a band of empty canvas below the fold.

## The fix

`ViewportService` follows `window.visualViewport` and publishes its height as `--app-visible-height`, which `ion-app` is sized to. The app then ends where the keyboard begins, the review screen fits inside it, and the browser has nothing left to scroll. Where `interactive-widget` *is* supported (Chrome, Firefox) the meta now asks for the same reflow natively, and the service agrees with it rather than fighting it.

Below 480px of visible height the review screen also trades its gutters for content. Margins only, deliberately: the reserved line heights are what hold space for the question sentence, and the word row is sized by its furigana, so shrinking either would let the layout shift again while a question loads. A first attempt at a tighter `line-height` did exactly that — it dropped the line box below the help icon's height and reintroduced a 1-2px drift — so it was dropped.

Basing the trigger on visible height rather than on detecting a keyboard covers all three cases uniformly: Safari's shrinking visual viewport, Chrome's native layout resize, and a phone in landscape.

## Verification

Measured on the review screen with the visible height at 270px, 420px and full desktop:

- At 420px visible (a typical phone with the keyboard up) the app is exactly 420px tall, the content totals 420px, and `ion-content` is **not scrollable** — the question card, answer field and Skip row all fit.
- Simulating the iOS case directly (layout viewport 800px, visible height 420px) puts the app at 420px with the field at 202-254px and nothing scrollable; the 380px below is where the keyboard sits.
- On an answered question at 420px visible there is 20px of overflow, and at maximum scroll the card (98px) and field (182-234px) both stay fully visible.
- The published variable tracks a live viewport resize without a reload (270px to 800px).
- `--app-visible-height` equals `innerHeight` wherever the visual viewport is not shrunk, so `ion-app` resolves to the same height as before on desktop and Android. The guide still scrolls (1880px of content in an 800px viewport), and preferences, home and summary are unchanged.
- `ng lint`, `ng build` and all 21 unit tests pass.

## Known limitations

- Not verifiable locally on iOS Safari: the visual viewport cannot be shrunk without a real keyboard, so the geometry was verified by pinning the height the service would publish. Worth a device pass.
- If Safari pans the visual viewport *before* the reflow lands, that first pan is not compensated — the service reacts to `resize`, it does not transform the app by `visualViewport.offsetTop`. Panning should settle once nothing is obscured; if it turns out to persist, offset compensation is the next lever.
- The keyboard still cannot be opened programmatically on the first question — iOS only opens it from a user gesture, so neither `autofocus` nor a delayed `focus()` shows it. See the PR discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)