### PR TITLE
Reload for a new version once, not forever

### DIFF
--- a/src/app/shared/update.service.spec.ts
+++ b/src/app/shared/update.service.spec.ts
@@ -1,0 +1,130 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { SwUpdate, VersionEvent } from '@angular/service-worker';
+import { Subject } from 'rxjs';
+
+import { UpdateService } from './update.service';
+
+const RELOADED_FOR = 'katsu.reloaded-for';
+
+function ready(hash: string): VersionEvent {
+  return {
+    type: 'VERSION_READY',
+    currentVersion: { hash: 'old' },
+    latestVersion: { hash },
+  } as VersionEvent;
+}
+
+/**
+ * A stand-in for the worker: the events it announces, plus a count of how often
+ * the app asked it to activate.
+ */
+class FakeSwUpdate {
+  readonly versionUpdates = new Subject<VersionEvent>();
+  readonly unrecoverable = new Subject<{ type: 'UNRECOVERABLE_STATE'; reason: string }>();
+  isEnabled = true;
+  activated = 0;
+  checks = 0;
+
+  activateUpdate(): Promise<boolean> {
+    this.activated++;
+    return Promise.resolve(true);
+  }
+
+  checkForUpdate(): Promise<boolean> {
+    this.checks++;
+    return Promise.resolve(true);
+  }
+}
+
+function setUp(url = '/home') {
+  const swUpdate = new FakeSwUpdate();
+  const reload = vi.fn();
+
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    providers: [
+      { provide: SwUpdate, useValue: swUpdate },
+      { provide: Router, useValue: { url, events: new Subject() } },
+    ],
+  });
+  const service = TestBed.inject(UpdateService);
+  // jsdom's location cannot be assigned to, so stand a whole one in.
+  vi.stubGlobal('location', { reload, href: `http://localhost${url}` });
+  service.start();
+
+  return { service, swUpdate, reload };
+}
+
+describe('UpdateService', () => {
+  beforeEach(() => sessionStorage.removeItem(RELOADED_FOR));
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('activates the new version before reloading, so it is not offered again', async () => {
+    const { swUpdate, reload } = setUp();
+
+    swUpdate.versionUpdates.next(ready('new'));
+    await vi.waitFor(() => expect(reload).toHaveBeenCalledOnce());
+
+    expect(swUpdate.activated).toBe(1);
+  });
+
+  /** The loop that left the tab spinning on a navigation that never committed. */
+  it('reloads once for a version, however often it is announced', async () => {
+    const { swUpdate, reload } = setUp();
+
+    swUpdate.versionUpdates.next(ready('new'));
+    await vi.waitFor(() => expect(reload).toHaveBeenCalledOnce());
+
+    for (let i = 0; i < 5; i++) {
+      swUpdate.versionUpdates.next(ready('new'));
+    }
+    await Promise.resolve();
+
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it('does not reload again after the reload, when the version is still announced', async () => {
+    const first = setUp();
+    first.swUpdate.versionUpdates.next(ready('new'));
+    await vi.waitFor(() => expect(first.reload).toHaveBeenCalledOnce());
+
+    // A new tab from the reload: same sessionStorage, same version pending.
+    const second = setUp();
+    second.swUpdate.versionUpdates.next(ready('new'));
+    await Promise.resolve();
+
+    expect(second.reload).not.toHaveBeenCalled();
+  });
+
+  it('still takes a further version, so a second deploy is not missed', async () => {
+    const first = setUp();
+    first.swUpdate.versionUpdates.next(ready('new'));
+    await vi.waitFor(() => expect(first.reload).toHaveBeenCalledOnce());
+
+    // The tab the reload left behind, and another deploy since.
+    const second = setUp();
+    second.swUpdate.versionUpdates.next(ready('newer'));
+
+    await vi.waitFor(() => expect(second.reload).toHaveBeenCalledOnce());
+  });
+
+  it('leaves a practice round alone', async () => {
+    const { swUpdate, reload } = setUp('/review');
+
+    swUpdate.versionUpdates.next(ready('new'));
+    await Promise.resolve();
+
+    expect(reload).not.toHaveBeenCalled();
+    expect(swUpdate.activated).toBe(0);
+  });
+
+  it('checks for an update when the tab comes back, but not repeatedly', () => {
+    const { swUpdate } = setUp();
+
+    document.dispatchEvent(new Event('visibilitychange'));
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(swUpdate.checks).toBeLessThanOrEqual(1);
+  });
+});

--- a/src/app/shared/update.service.ts
+++ b/src/app/shared/update.service.ts
@@ -1,18 +1,36 @@
 import { Injectable, inject } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
-import { SwUpdate } from '@angular/service-worker';
+import { SwUpdate, VersionReadyEvent } from '@angular/service-worker';
 import { filter } from 'rxjs';
 
+/** Which version this tab has already reloaded for, so it cannot do it twice. */
+const RELOADED_FOR = 'katsu.reloaded-for';
+
+/** How stale an update check may be before returning to the tab repeats it. */
+const CHECK_INTERVAL_MS = 15 * 60 * 1000;
+
 /**
- * Reload the app as soon as the service worker has downloaded a new version,
- * so users get updates on their first visit instead of the second.
+ * Reload the app once the service worker has a new version ready, so users get
+ * updates on their first visit instead of the second.
+ *
+ * Every reload here has to be provably the last one. A worker announces a
+ * version as ready until it is activated, so reloading without activating means
+ * being told again on the next load - a loop that leaves the tab spinning on a
+ * navigation that never commits. Hence: activate first, and remember the version
+ * reloaded for in sessionStorage, which outlives the reload the way a field
+ * cannot.
  */
 @Injectable({ providedIn: 'root' })
 export class UpdateService {
   private readonly swUpdate = inject(SwUpdate);
   private readonly router = inject(Router);
 
-  private updateReady = false;
+  /** The version waiting to be activated, if any. */
+  private pending?: string;
+
+  private reloading = false;
+
+  private lastCheck = Date.now();
 
   start() {
     if (!this.swUpdate.isEnabled) {
@@ -20,35 +38,96 @@ export class UpdateService {
     }
 
     this.swUpdate.versionUpdates
-      .pipe(filter(event => event.type === 'VERSION_READY'))
-      .subscribe(() => {
-        this.updateReady = true;
-        this.reloadWhenSafe();
+      .pipe(filter((event): event is VersionReadyEvent => event.type === 'VERSION_READY'))
+      .subscribe(event => {
+        this.pending = event.latestVersion.hash;
+        void this.reloadWhenSafe();
       });
+
+    // A worker whose caches no longer add up cannot be repaired by reloading:
+    // it has to go, and the plain network takes over until the next visit.
+    this.swUpdate.unrecoverable.subscribe(() => void this.discardWorker());
 
     // If a reload was deferred, retry after each navigation
     this.router.events
       .pipe(filter(event => event instanceof NavigationEnd))
       .subscribe(() => {
-        if (this.updateReady) {
-          this.reloadWhenSafe();
+        if (this.pending) {
+          void this.reloadWhenSafe();
         }
       });
 
     // The worker only looks for new versions on page load, which a tab left
-    // open never does. Coming back into view is the next best moment.
-    document.addEventListener('visibilitychange', () => {
-      if (document.visibilityState === 'visible') {
-        this.swUpdate.checkForUpdate().catch(() => undefined);
-      }
-    });
+    // open never does. Coming back into view is the next best moment, at most
+    // once a quarter of an hour.
+    document.addEventListener('visibilitychange', () => this.checkOnReturn());
   }
 
-  private reloadWhenSafe() {
+  private async reloadWhenSafe(): Promise<void> {
+    const version = this.pending;
+
+    if (!version || this.reloading) {
+      return;
+    }
     // Don't interrupt an active practice round
     if (this.router.url.startsWith('/review')) {
       return;
     }
+    if (this.alreadyReloadedFor(version)) {
+      return;
+    }
+    this.reloading = true;
+    this.remember(version);
+
+    try {
+      // Without this the version stays ready and says so again after the
+      // reload, which is the loop this guards against twice over.
+      await this.swUpdate.activateUpdate();
+    } catch {
+      // Activation failed, so the reload below is this tab's one attempt.
+    }
     location.reload();
+  }
+
+  private checkOnReturn(): void {
+    if (document.visibilityState !== 'visible' || this.reloading) {
+      return;
+    }
+    if (Date.now() - this.lastCheck < CHECK_INTERVAL_MS) {
+      return;
+    }
+    this.lastCheck = Date.now();
+    this.swUpdate.checkForUpdate().catch(() => undefined);
+  }
+
+  private async discardWorker(): Promise<void> {
+    if (this.reloading) {
+      return;
+    }
+    this.reloading = true;
+    try {
+      const registration = await navigator.serviceWorker?.getRegistration();
+      await registration?.unregister();
+    } catch {
+      // Nothing to unregister; the reload is still worth a try.
+    }
+    location.reload();
+  }
+
+  private alreadyReloadedFor(version: string): boolean {
+    try {
+      return sessionStorage.getItem(RELOADED_FOR) === version;
+    } catch {
+      // No sessionStorage means no guard, and a loop is worse than a stale tab.
+      return true;
+    }
+  }
+
+  private remember(version: string): void {
+    try {
+      sessionStorage.setItem(RELOADED_FOR, version);
+    } catch {
+      // Private browsing; the in-memory flag is the only guard left.
+    }
   }
 }


### PR DESCRIPTION
After the last deploy Arthur's tab sat spinning: the app rendered fine, but Chrome showed `GET /home` pending indefinitely — a navigation being restarted before it could commit. A reload loop.

## Cause

A service worker keeps announcing a version as ready until it is activated. `UpdateService` reloaded on `VERSION_READY` but **never called `activateUpdate()`**, so after the reload the same version was announced again, which triggered the next reload.

The bug was already there; what hid it was that `VERSION_READY` only fired on page load. The `visibilitychange` check added in #66 made it fire every time the tab came back, and the loop found its footing.

## Fix

Three guards, because a reload loop leaves no way to reach the app and fix it from the inside:

- **`activateUpdate()` before reloading**, so the version stops being pending.
- **The version reloaded for goes in `sessionStorage`**, which outlives the reload the way a field cannot. Keyed by version hash, so a second deploy is still picked up while a stale one cannot be retried.
- **An unrecoverable worker is unregistered**, not reloaded at. Caches that no longer add up cannot be repaired by trying again; the plain network serves the app until the next visit.

The visibility check keeps its job, throttled to once every 15 minutes.

## Tests

`update.service.spec.ts` is new and covers the loop directly: five announcements of one version produce one reload; a version already reloaded for, announced again in the next tab, produces none; a newer version still gets through; `/review` is left alone. 123 tests pass.

## Separate hygiene issue — a Cloudflare change, not a repo one

`ngsw-worker.js` comes back with `cache-control: max-age=31536000` and `cf-cache-status: HIT`, and `ngsw.json` with `max-age=600`.

This did **not** cause the loop, and it does not leave browsers stuck on an old worker: the top-level worker script is fetched with `no-cache` on every update check by default (`updateViaCache: 'imports'`). What it does cause is **delayed update detection** — Cloudflare's edge can serve a stale worker or manifest even when the browser asks for a fresh one. Worth a cache rule bypassing `/ngsw-worker.js`, `/ngsw.json` and `/safety-worker.js`; the hashed `main-*.js` files should keep their long TTL, since their names are content-addressed.