### PR TITLE
Recover from cached HTML that points at a deleted bundle

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -79,6 +79,45 @@
 <body>
   <app-root></app-root>
   <noscript>Please enable JavaScript to continue using this application.</noscript>
+
+  <!--
+    Boot watchdog. GitHub Pages serves this file with max-age=600 and deletes
+    the previous build's hashed scripts, so for ten minutes after a deploy a
+    normal refresh can hand a returning visitor cached HTML pointing at a
+    main-<hash>.js that is gone. Angular then never boots and the page sits
+    empty, which no amount of ordinary reloading fixes.
+
+    So: if nothing has rendered, fetch this page again past the HTTP cache -
+    which also replaces the stale entry - and load the fresh copy. Once per
+    tab, because a reload that can repeat is worse than the fault it treats.
+  -->
+  <script>
+    (function () {
+      var KEY = 'katsu.boot-retry';
+      var WAIT_MS = 10000;
+
+      function booted() {
+        var root = document.querySelector('app-root');
+        return !!root && root.childElementCount > 0;
+      }
+
+      setTimeout(function () {
+        if (booted()) {
+          try { sessionStorage.removeItem(KEY); } catch (e) { /* nothing to clear */ }
+          return;
+        }
+        try {
+          if (sessionStorage.getItem(KEY)) { return; }
+          sessionStorage.setItem(KEY, '1');
+        } catch (e) {
+          return; // No sessionStorage, so no way to stop at one attempt.
+        }
+        fetch(location.href, { cache: 'reload' }).then(function () {
+          location.reload();
+        }, function () { /* offline: the cached page is all there is */ });
+      }, WAIT_MS);
+    })();
+  </script>
 </body>
 
 </html>


### PR DESCRIPTION
A normal refresh landed on an empty page while a hard refresh worked. That difference is the browser's HTTP cache, not the service worker.

## Cause

GitHub Pages serves `index.html` with `cache-control: max-age=600`, and a deploy deletes the previous build's hashed scripts. So for ten minutes after every deploy, a returning visitor's normal refresh can be handed cached HTML that asks for a `main-<hash>.js` which no longer exists. Angular never boots, the page sits empty — and reloading does not help, because the reload is served from the same cache. Only a hard refresh (which bypasses it) escapes.

Measured on production:

```
GET /home/  →  200, cache-control: max-age=600, cf-cache-status: DYNAMIC
```

This affects every returning visitor after every deploy, not just one browser.

## Fix

A watchdog in `index.html`: if nothing has rendered after ten seconds, refetch the page with `cache: 'reload'` — which also replaces the stale cache entry — then load the fresh copy. Once per tab, recorded in `sessionStorage`, because a reload that can repeat is worse than the fault it treats.

## Verified in the browser, both branches

- **Healthy boot:** the watchdog leaves the page alone and clears its marker.
- **Nothing rendered:** the shipped script (extracted from the page, with the DOM check and network calls stubbed) refetches exactly once with `{cache: 'reload'}` and reloads exactly once — then does nothing when the retried load runs it again.

123 tests, lint and build pass.

## Scope

This is a safety net, not the whole answer. A healthy service worker already serves navigations from one consistent version, which is why the fault only surfaced while the worker was unregistered (during the #67 investigation). The tidy fix is a Cloudflare rule keeping HTML out of the browser cache, but that cannot live in the repo.