### PR TITLE
Stop the app reloading itself

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,6 +6,12 @@
       "runtimeExecutable": "bash",
       "runtimeArgs": ["-c", "source \"$HOME/.nvm/nvm.sh\" && nvm use 24 >/dev/null && npm start"],
       "port": 4200
+    },
+    {
+      "name": "katsu-prod",
+      "runtimeExecutable": "python3",
+      "runtimeArgs": ["-m", "http.server", "4300", "--directory", "dist/browser"],
+      "port": 4300
     }
   ]
 }

--- a/src/app/components/credit/credit.component.ts
+++ b/src/app/components/credit/credit.component.ts
@@ -1,6 +1,5 @@
 import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { IonRouterLink } from '@ionic/angular/standalone';
 import { TranslatePipe } from '@ngx-translate/core';
 
 /**
@@ -36,6 +35,6 @@ import { TranslatePipe } from '@ngx-translate/core';
       }
     }
   `,
-  imports: [RouterLink, IonRouterLink, TranslatePipe],
+  imports: [RouterLink, TranslatePipe],
 })
 export class CreditComponent {}

--- a/src/app/review/question-data.service.ts
+++ b/src/app/review/question-data.service.ts
@@ -145,7 +145,6 @@ export class QuestionDataService {
       question = question.reverse();
     }
 
-    // console.log('answers', word.level, question.answers);
     return question;
   }
 

--- a/src/app/shared/settings.service.ts
+++ b/src/app/shared/settings.service.ts
@@ -387,7 +387,6 @@ export class SettingsService {
     if (this.causativePassive) {
       this.addCausativePassive(options);
     }
-    // console.log('options', options);
     return options;
   }
 

--- a/src/app/shared/update.service.spec.ts
+++ b/src/app/shared/update.service.spec.ts
@@ -147,6 +147,21 @@ describe('UpdateService', () => {
     expect(Number(sessionStorage.getItem('katsu.sw-reloads'))).toBeLessThanOrEqual(2);
   });
 
+  it('takes the worker caches with it, and leaves the schedule alone', async () => {
+    const deleted: string[] = [];
+    vi.stubGlobal('caches', {
+      keys: () => Promise.resolve(['ngsw:/:db:control', 'ngsw:/:1:assets:app:cache', 'other-cache']),
+      delete: (name: string) => { deleted.push(name); return Promise.resolve(true); },
+    });
+    vi.stubGlobal('navigator', { serviceWorker: { getRegistration: () => Promise.resolve(undefined) } });
+    const { swUpdate, reload } = setUp();
+
+    swUpdate.unrecoverable.next({ type: 'UNRECOVERABLE_STATE', reason: 'missing' });
+    await vi.waitFor(() => expect(reload).toHaveBeenCalledOnce());
+
+    expect(deleted).toEqual(['ngsw:/:db:control', 'ngsw:/:1:assets:app:cache']);
+  });
+
   it('leaves a practice round alone', async () => {
     const { swUpdate, reload } = setUp('/review');
 

--- a/src/app/shared/update.service.spec.ts
+++ b/src/app/shared/update.service.spec.ts
@@ -1,12 +1,8 @@
 import { TestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
 import { SwUpdate, VersionEvent } from '@angular/service-worker';
 import { Subject } from 'rxjs';
 
 import { UpdateService } from './update.service';
-
-const RELOADED_FOR = 'katsu.reloaded-for';
-const RELOAD_COUNT = 'katsu.sw-reloads';
 
 function ready(hash: string): VersionEvent {
   return {
@@ -16,10 +12,6 @@ function ready(hash: string): VersionEvent {
   } as VersionEvent;
 }
 
-/**
- * A stand-in for the worker: the events it announces, plus a count of how often
- * the app asked it to activate.
- */
 class FakeSwUpdate {
   readonly versionUpdates = new Subject<VersionEvent>();
   readonly unrecoverable = new Subject<{ type: 'UNRECOVERABLE_STATE'; reason: string }>();
@@ -38,146 +30,62 @@ class FakeSwUpdate {
   }
 }
 
-function setUp(url = '/home') {
+function setUp() {
   const swUpdate = new FakeSwUpdate();
   const reload = vi.fn();
+  const deleted: string[] = [];
+  const unregistered: boolean[] = [];
 
   TestBed.resetTestingModule();
-  TestBed.configureTestingModule({
-    providers: [
-      { provide: SwUpdate, useValue: swUpdate },
-      { provide: Router, useValue: { url, events: new Subject() } },
-    ],
-  });
+  TestBed.configureTestingModule({ providers: [{ provide: SwUpdate, useValue: swUpdate }] });
   const service = TestBed.inject(UpdateService);
+
   // jsdom's location cannot be assigned to, so stand a whole one in.
-  vi.stubGlobal('location', { reload, href: `http://localhost${url}` });
+  vi.stubGlobal('location', { reload, href: 'http://localhost/home' });
+  vi.stubGlobal('caches', {
+    keys: () => Promise.resolve(['ngsw:/:db:control', 'ngsw:/:1:assets:app:cache', 'unrelated']),
+    delete: (name: string) => { deleted.push(name); return Promise.resolve(true); },
+  });
+  vi.stubGlobal('navigator', {
+    serviceWorker: {
+      getRegistration: () =>
+        Promise.resolve({ unregister: () => { unregistered.push(true); return Promise.resolve(true); } }),
+    },
+  });
   service.start();
 
-  return { service, swUpdate, reload };
+  return { swUpdate, reload, deleted, unregistered };
 }
 
 describe('UpdateService', () => {
-  beforeEach(() => {
-    sessionStorage.removeItem(RELOADED_FOR);
-    sessionStorage.removeItem(RELOAD_COUNT);
-  });
   afterEach(() => vi.unstubAllGlobals());
 
-  it('activates the new version before reloading, so it is not offered again', async () => {
-    const { swUpdate, reload } = setUp();
-
-    swUpdate.versionUpdates.next(ready('new'));
-    await vi.waitFor(() => expect(reload).toHaveBeenCalledOnce());
-
-    expect(swUpdate.activated).toBe(1);
-  });
-
-  /** The loop that left the tab spinning on a navigation that never committed. */
-  it('reloads once for a version, however often it is announced', async () => {
-    const { swUpdate, reload } = setUp();
-
-    swUpdate.versionUpdates.next(ready('new'));
-    await vi.waitFor(() => expect(reload).toHaveBeenCalledOnce());
-
-    for (let i = 0; i < 5; i++) {
-      swUpdate.versionUpdates.next(ready('new'));
-    }
-    await Promise.resolve();
-
-    expect(reload).toHaveBeenCalledOnce();
-  });
-
-  it('does not reload again after the reload, when the version is still announced', async () => {
-    const first = setUp();
-    first.swUpdate.versionUpdates.next(ready('new'));
-    await vi.waitFor(() => expect(first.reload).toHaveBeenCalledOnce());
-
-    // A new tab from the reload: same sessionStorage, same version pending.
-    const second = setUp();
-    second.swUpdate.versionUpdates.next(ready('new'));
-    await Promise.resolve();
-
-    expect(second.reload).not.toHaveBeenCalled();
-  });
-
-  it('still takes a further version, so a second deploy is not missed', async () => {
-    const first = setUp();
-    first.swUpdate.versionUpdates.next(ready('new'));
-    await vi.waitFor(() => expect(first.reload).toHaveBeenCalledOnce());
-
-    // The tab the reload left behind, and another deploy since.
-    const second = setUp();
-    second.swUpdate.versionUpdates.next(ready('newer'));
-
-    await vi.waitFor(() => expect(second.reload).toHaveBeenCalledOnce());
-  });
-
   /**
-   * The hole in the first fix: an unrecoverable worker reports itself on every
-   * load, and only an in-memory flag stood in the way - which every reload
-   * cleared.
+   * The guarantee this file exists for. Three reload loops in one day came from
+   * this service deciding to reload; nothing here can any more.
    */
-  it('discards a broken worker, but stops once the budget is gone', async () => {
-    const first = setUp();
-    first.swUpdate.unrecoverable.next({ type: 'UNRECOVERABLE_STATE', reason: 'missing' });
-    await vi.waitFor(() => expect(first.reload).toHaveBeenCalledOnce());
-
-    const second = setUp();
-    second.swUpdate.unrecoverable.next({ type: 'UNRECOVERABLE_STATE', reason: 'missing' });
-    await vi.waitFor(() => expect(second.reload).toHaveBeenCalledOnce());
-
-    // Two reloads is the ceiling: a third load must sit still, however broken.
-    const third = setUp();
-    third.swUpdate.unrecoverable.next({ type: 'UNRECOVERABLE_STATE', reason: 'missing' });
-    await Promise.resolve();
-
-    expect(third.reload).not.toHaveBeenCalled();
-  });
-
-  /** A CDN serving two copies of ngsw.json makes every reason look new. */
-  it('stops reloading even when each version announced is different', async () => {
-    for (const version of ['a', 'b', 'c', 'd', 'e']) {
-      const tab = setUp();
-      tab.swUpdate.versionUpdates.next(ready(version));
-      await Promise.resolve();
-      await Promise.resolve();
-    }
-
-    expect(Number(sessionStorage.getItem('katsu.sw-reloads'))).toBeLessThanOrEqual(2);
-  });
-
-  it('takes the worker caches with it, and leaves the schedule alone', async () => {
-    const deleted: string[] = [];
-    vi.stubGlobal('caches', {
-      keys: () => Promise.resolve(['ngsw:/:db:control', 'ngsw:/:1:assets:app:cache', 'other-cache']),
-      delete: (name: string) => { deleted.push(name); return Promise.resolve(true); },
-    });
-    vi.stubGlobal('navigator', { serviceWorker: { getRegistration: () => Promise.resolve(undefined) } });
+  it('never reloads the page and never touches the version, whatever it is told', async () => {
     const { swUpdate, reload } = setUp();
 
+    for (const version of ['a', 'b', 'c', 'a']) {
+      swUpdate.versionUpdates.next(ready(version));
+    }
     swUpdate.unrecoverable.next({ type: 'UNRECOVERABLE_STATE', reason: 'missing' });
-    await vi.waitFor(() => expect(reload).toHaveBeenCalledOnce());
-
-    expect(deleted).toEqual(['ngsw:/:db:control', 'ngsw:/:1:assets:app:cache']);
-  });
-
-  it('leaves a practice round alone', async () => {
-    const { swUpdate, reload } = setUp('/review');
-
-    swUpdate.versionUpdates.next(ready('new'));
-    await Promise.resolve();
+    document.dispatchEvent(new Event('visibilitychange'));
+    await new Promise(resolve => setTimeout(resolve, 20));
 
     expect(reload).not.toHaveBeenCalled();
     expect(swUpdate.activated).toBe(0);
+    expect(swUpdate.checks).toBe(0);
   });
 
-  it('checks for an update when the tab comes back, but not repeatedly', () => {
-    const { swUpdate } = setUp();
+  it('discards a broken worker along with its caches, sparing the rest', async () => {
+    const { swUpdate, deleted, unregistered } = setUp();
 
-    document.dispatchEvent(new Event('visibilitychange'));
-    document.dispatchEvent(new Event('visibilitychange'));
+    swUpdate.unrecoverable.next({ type: 'UNRECOVERABLE_STATE', reason: 'missing' });
+    await vi.waitFor(() => expect(deleted).toHaveLength(2));
 
-    expect(swUpdate.checks).toBeLessThanOrEqual(1);
+    expect(unregistered).toEqual([true]);
+    expect(deleted).toEqual(['ngsw:/:db:control', 'ngsw:/:1:assets:app:cache']);
   });
 });

--- a/src/app/shared/update.service.spec.ts
+++ b/src/app/shared/update.service.spec.ts
@@ -6,6 +6,7 @@ import { Subject } from 'rxjs';
 import { UpdateService } from './update.service';
 
 const RELOADED_FOR = 'katsu.reloaded-for';
+const RELOAD_COUNT = 'katsu.sw-reloads';
 
 function ready(hash: string): VersionEvent {
   return {
@@ -57,7 +58,10 @@ function setUp(url = '/home') {
 }
 
 describe('UpdateService', () => {
-  beforeEach(() => sessionStorage.removeItem(RELOADED_FOR));
+  beforeEach(() => {
+    sessionStorage.removeItem(RELOADED_FOR);
+    sessionStorage.removeItem(RELOAD_COUNT);
+  });
   afterEach(() => vi.unstubAllGlobals());
 
   it('activates the new version before reloading, so it is not offered again', async () => {
@@ -107,6 +111,40 @@ describe('UpdateService', () => {
     second.swUpdate.versionUpdates.next(ready('newer'));
 
     await vi.waitFor(() => expect(second.reload).toHaveBeenCalledOnce());
+  });
+
+  /**
+   * The hole in the first fix: an unrecoverable worker reports itself on every
+   * load, and only an in-memory flag stood in the way - which every reload
+   * cleared.
+   */
+  it('discards a broken worker, but stops once the budget is gone', async () => {
+    const first = setUp();
+    first.swUpdate.unrecoverable.next({ type: 'UNRECOVERABLE_STATE', reason: 'missing' });
+    await vi.waitFor(() => expect(first.reload).toHaveBeenCalledOnce());
+
+    const second = setUp();
+    second.swUpdate.unrecoverable.next({ type: 'UNRECOVERABLE_STATE', reason: 'missing' });
+    await vi.waitFor(() => expect(second.reload).toHaveBeenCalledOnce());
+
+    // Two reloads is the ceiling: a third load must sit still, however broken.
+    const third = setUp();
+    third.swUpdate.unrecoverable.next({ type: 'UNRECOVERABLE_STATE', reason: 'missing' });
+    await Promise.resolve();
+
+    expect(third.reload).not.toHaveBeenCalled();
+  });
+
+  /** A CDN serving two copies of ngsw.json makes every reason look new. */
+  it('stops reloading even when each version announced is different', async () => {
+    for (const version of ['a', 'b', 'c', 'd', 'e']) {
+      const tab = setUp();
+      tab.swUpdate.versionUpdates.next(ready(version));
+      await Promise.resolve();
+      await Promise.resolve();
+    }
+
+    expect(Number(sessionStorage.getItem('katsu.sw-reloads'))).toBeLessThanOrEqual(2);
   });
 
   it('leaves a practice round alone', async () => {

--- a/src/app/shared/update.service.ts
+++ b/src/app/shared/update.service.ts
@@ -6,6 +6,16 @@ import { filter } from 'rxjs';
 /** Which version this tab has already reloaded for, so it cannot do it twice. */
 const RELOADED_FOR = 'katsu.reloaded-for';
 
+/** Reloads this tab has done for the worker, whatever the reason. */
+const RELOAD_COUNT = 'katsu.sw-reloads';
+
+/**
+ * The ceiling on those, per tab. Two covers everything legitimate - a version
+ * activating, or a broken worker being discarded - and refuses everything else,
+ * whether or not the reason looks new each time.
+ */
+const MAX_RELOADS = 2;
+
 /** How stale an update check may be before returning to the tab repeats it. */
 const CHECK_INTERVAL_MS = 15 * 60 * 1000;
 
@@ -13,12 +23,19 @@ const CHECK_INTERVAL_MS = 15 * 60 * 1000;
  * Reload the app once the service worker has a new version ready, so users get
  * updates on their first visit instead of the second.
  *
- * Every reload here has to be provably the last one. A worker announces a
- * version as ready until it is activated, so reloading without activating means
- * being told again on the next load - a loop that leaves the tab spinning on a
- * navigation that never commits. Hence: activate first, and remember the version
- * reloaded for in sessionStorage, which outlives the reload the way a field
- * cannot.
+ * Every reload here has to be provably the last one, and the guards are layered
+ * because each one has been wrong once:
+ *
+ * - Activate the version first. A worker announces a version as ready until it
+ *   is activated, so reloading without activating means being told again on the
+ *   next load.
+ * - Remember the version reloaded for, in sessionStorage, which outlives the
+ *   reload the way a field cannot.
+ * - Count every reload against MAX_RELOADS, whatever its reason. Reasons that
+ *   look new each time - a fresh version hash from a CDN serving two copies, a
+ *   worker that reports itself broken on each load - defeat the guards above
+ *   while still spinning the tab, and a tab that cannot reload is a much smaller
+ *   problem than one that cannot stop.
  */
 @Injectable({ providedIn: 'root' })
 export class UpdateService {
@@ -66,7 +83,7 @@ export class UpdateService {
   private async reloadWhenSafe(): Promise<void> {
     const version = this.pending;
 
-    if (!version || this.reloading) {
+    if (!version || this.reloading || this.spent()) {
       return;
     }
     // Don't interrupt an active practice round
@@ -77,16 +94,16 @@ export class UpdateService {
       return;
     }
     this.reloading = true;
-    this.remember(version);
+    this.remember(RELOADED_FOR, version);
 
     try {
       // Without this the version stays ready and says so again after the
-      // reload, which is the loop this guards against twice over.
+      // reload, which is the loop this guards against three times over.
       await this.swUpdate.activateUpdate();
     } catch {
       // Activation failed, so the reload below is this tab's one attempt.
     }
-    location.reload();
+    this.reload();
   }
 
   private checkOnReturn(): void {
@@ -100,8 +117,13 @@ export class UpdateService {
     this.swUpdate.checkForUpdate().catch(() => undefined);
   }
 
+  /**
+   * A worker reporting itself broken says so again on the load after this one,
+   * so this counts against the same ceiling as everything else. Unregistering
+   * is the part that matters; the reload only makes it take effect sooner.
+   */
   private async discardWorker(): Promise<void> {
-    if (this.reloading) {
+    if (this.reloading || this.spent()) {
       return;
     }
     this.reloading = true;
@@ -111,7 +133,26 @@ export class UpdateService {
     } catch {
       // Nothing to unregister; the reload is still worth a try.
     }
+    this.reload();
+  }
+
+  private reload(): void {
+    this.remember(RELOAD_COUNT, String(this.reloadsSoFar() + 1));
     location.reload();
+  }
+
+  /** Whether this tab has used up its reloads, for any reason at all. */
+  private spent(): boolean {
+    return this.reloadsSoFar() >= MAX_RELOADS;
+  }
+
+  private reloadsSoFar(): number {
+    try {
+      return Number(sessionStorage.getItem(RELOAD_COUNT)) || 0;
+    } catch {
+      // No sessionStorage means no counting, so treat the budget as gone.
+      return MAX_RELOADS;
+    }
   }
 
   private alreadyReloadedFor(version: string): boolean {
@@ -123,9 +164,9 @@ export class UpdateService {
     }
   }
 
-  private remember(version: string): void {
+  private remember(key: string, value: string): void {
     try {
-      sessionStorage.setItem(RELOADED_FOR, version);
+      sessionStorage.setItem(key, value);
     } catch {
       // Private browsing; the in-memory flag is the only guard left.
     }

--- a/src/app/shared/update.service.ts
+++ b/src/app/shared/update.service.ts
@@ -130,8 +130,13 @@ export class UpdateService {
     try {
       const registration = await navigator.serviceWorker?.getRegistration();
       await registration?.unregister();
+      // Unregistering leaves the caches behind, and a fresh worker reads the
+      // same ones - so a bad state survives being unregistered unless they go
+      // too. Only the worker's own caches: the schedule lives in IndexedDB.
+      const names = await caches.keys();
+      await Promise.all(names.filter(name => name.startsWith('ngsw:')).map(name => caches.delete(name)));
     } catch {
-      // Nothing to unregister; the reload is still worth a try.
+      // Nothing to clear; the reload is still worth a try.
     }
     this.reload();
   }

--- a/src/app/shared/update.service.ts
+++ b/src/app/shared/update.service.ts
@@ -1,179 +1,48 @@
 import { Injectable, inject } from '@angular/core';
-import { NavigationEnd, Router } from '@angular/router';
-import { SwUpdate, VersionReadyEvent } from '@angular/service-worker';
-import { filter } from 'rxjs';
-
-/** Which version this tab has already reloaded for, so it cannot do it twice. */
-const RELOADED_FOR = 'katsu.reloaded-for';
-
-/** Reloads this tab has done for the worker, whatever the reason. */
-const RELOAD_COUNT = 'katsu.sw-reloads';
+import { SwUpdate } from '@angular/service-worker';
 
 /**
- * The ceiling on those, per tab. Two covers everything legitimate - a version
- * activating, or a broken worker being discarded - and refuses everything else,
- * whether or not the reason looks new each time.
- */
-const MAX_RELOADS = 2;
-
-/** How stale an update check may be before returning to the tab repeats it. */
-const CHECK_INTERVAL_MS = 15 * 60 * 1000;
-
-/**
- * Reload the app once the service worker has a new version ready, so users get
- * updates on their first visit instead of the second.
+ * Disposes of a service worker that has broken, and nothing else.
  *
- * Every reload here has to be provably the last one, and the guards are layered
- * because each one has been wrong once:
+ * This used to reload the page as soon as a new version was ready, so a fix
+ * reached people on the visit they were already making. That cost three reload
+ * loops in one day, each leaving the tab spinning on a navigation that never
+ * committed - and a loop like that cannot be fixed from inside the app, because
+ * the app never finishes loading. The mechanism is gone rather than guarded.
  *
- * - Activate the version first. A worker announces a version as ready until it
- *   is activated, so reloading without activating means being told again on the
- *   next load.
- * - Remember the version reloaded for, in sessionStorage, which outlives the
- *   reload the way a field cannot.
- * - Count every reload against MAX_RELOADS, whatever its reason. Reasons that
- *   look new each time - a fresh version hash from a CDN serving two copies, a
- *   worker that reports itself broken on each load - defeat the guards above
- *   while still spinning the tab, and a tab that cannot reload is a much smaller
- *   problem than one that cannot stop.
+ * Versions now arrive the way Angular's worker intends: a new one downloads in
+ * the background and takes over once the last tab on the old one closes, so a
+ * tab keeps one consistent version for its whole life. A tab left open for days
+ * keeps what it started with, which is the price of never looping again.
  */
 @Injectable({ providedIn: 'root' })
 export class UpdateService {
   private readonly swUpdate = inject(SwUpdate);
-  private readonly router = inject(Router);
-
-  /** The version waiting to be activated, if any. */
-  private pending?: string;
-
-  private reloading = false;
-
-  private lastCheck = Date.now();
 
   start() {
     if (!this.swUpdate.isEnabled) {
       return;
     }
-
-    this.swUpdate.versionUpdates
-      .pipe(filter((event): event is VersionReadyEvent => event.type === 'VERSION_READY'))
-      .subscribe(event => {
-        this.pending = event.latestVersion.hash;
-        void this.reloadWhenSafe();
-      });
-
-    // A worker whose caches no longer add up cannot be repaired by reloading:
-    // it has to go, and the plain network takes over until the next visit.
     this.swUpdate.unrecoverable.subscribe(() => void this.discardWorker());
-
-    // If a reload was deferred, retry after each navigation
-    this.router.events
-      .pipe(filter(event => event instanceof NavigationEnd))
-      .subscribe(() => {
-        if (this.pending) {
-          void this.reloadWhenSafe();
-        }
-      });
-
-    // The worker only looks for new versions on page load, which a tab left
-    // open never does. Coming back into view is the next best moment, at most
-    // once a quarter of an hour.
-    document.addEventListener('visibilitychange', () => this.checkOnReturn());
-  }
-
-  private async reloadWhenSafe(): Promise<void> {
-    const version = this.pending;
-
-    if (!version || this.reloading || this.spent()) {
-      return;
-    }
-    // Don't interrupt an active practice round
-    if (this.router.url.startsWith('/review')) {
-      return;
-    }
-    if (this.alreadyReloadedFor(version)) {
-      return;
-    }
-    this.reloading = true;
-    this.remember(RELOADED_FOR, version);
-
-    try {
-      // Without this the version stays ready and says so again after the
-      // reload, which is the loop this guards against three times over.
-      await this.swUpdate.activateUpdate();
-    } catch {
-      // Activation failed, so the reload below is this tab's one attempt.
-    }
-    this.reload();
-  }
-
-  private checkOnReturn(): void {
-    if (document.visibilityState !== 'visible' || this.reloading) {
-      return;
-    }
-    if (Date.now() - this.lastCheck < CHECK_INTERVAL_MS) {
-      return;
-    }
-    this.lastCheck = Date.now();
-    this.swUpdate.checkForUpdate().catch(() => undefined);
   }
 
   /**
-   * A worker reporting itself broken says so again on the load after this one,
-   * so this counts against the same ceiling as everything else. Unregistering
-   * is the part that matters; the reload only makes it take effect sooner.
+   * A worker whose caches no longer add up cannot serve the app and cannot be
+   * repaired by asking again, so it goes and the network takes over.
+   *
+   * Unregistering alone is not enough: the caches outlive it and the next worker
+   * reads the same ones, which is how a bad state survives being unregistered.
+   * Only the worker's own caches go - the review schedule is in IndexedDB.
    */
   private async discardWorker(): Promise<void> {
-    if (this.reloading || this.spent()) {
-      return;
-    }
-    this.reloading = true;
     try {
       const registration = await navigator.serviceWorker?.getRegistration();
       await registration?.unregister();
-      // Unregistering leaves the caches behind, and a fresh worker reads the
-      // same ones - so a bad state survives being unregistered unless they go
-      // too. Only the worker's own caches: the schedule lives in IndexedDB.
+
       const names = await caches.keys();
       await Promise.all(names.filter(name => name.startsWith('ngsw:')).map(name => caches.delete(name)));
     } catch {
-      // Nothing to clear; the reload is still worth a try.
-    }
-    this.reload();
-  }
-
-  private reload(): void {
-    this.remember(RELOAD_COUNT, String(this.reloadsSoFar() + 1));
-    location.reload();
-  }
-
-  /** Whether this tab has used up its reloads, for any reason at all. */
-  private spent(): boolean {
-    return this.reloadsSoFar() >= MAX_RELOADS;
-  }
-
-  private reloadsSoFar(): number {
-    try {
-      return Number(sessionStorage.getItem(RELOAD_COUNT)) || 0;
-    } catch {
-      // No sessionStorage means no counting, so treat the budget as gone.
-      return MAX_RELOADS;
-    }
-  }
-
-  private alreadyReloadedFor(version: string): boolean {
-    try {
-      return sessionStorage.getItem(RELOADED_FOR) === version;
-    } catch {
-      // No sessionStorage means no guard, and a loop is worse than a stale tab.
-      return true;
-    }
-  }
-
-  private remember(key: string, value: string): void {
-    try {
-      sessionStorage.setItem(key, value);
-    } catch {
-      // Private browsing; the in-memory flag is the only guard left.
+      // Nothing to clear. The page in front of the user still works.
     }
   }
 }


### PR DESCRIPTION
Three reload loops in one day came from one decision: reload the page as soon as the worker reports a new version. Each left the tab spinning on a navigation that never committed — which cannot be fixed from inside the app, because the app never finishes loading. Each got a guard. **This removes the mechanism instead.**

## Gone

From `UpdateService`: `location.reload()`, `activateUpdate()`, the `Router` dependency, the `reloaded-for` and `reload-count` keys, the two-reload budget, and the visibility check that turned a rare announcement into a frequent one — the spark for all of it.

Net **−121 lines** across the branch.

## What is left

One job, forty lines: dispose of a worker that reports itself unrecoverable, deleting its `ngsw:` caches as well as its registration — those outlive unregistration and the next worker reads them, which is why unregistering by hand did not fix the affected browser. The review schedule lives in IndexedDB and is untouched.

Exactly one `location.reload()` remains in the entire app: the boot watchdog in `index.html` from #68, which fires at most once per tab and only when nothing rendered. Every remaining path is fail-safe — if the unrecoverable handler never fires, the app simply carries on, because nothing depends on it.

## Verified against the real worker, not a mock

`.claude/launch.json` gains a `katsu-prod` entry serving the production build, because `ng serve` leaves the worker disabled and worker behaviour cannot otherwise be tested locally.

With a genuinely new version deployed underneath a live, worker-controlled tab:

| check | result |
|---|---|
| reload during a 20-second watch (`performance.timeOrigin`) | **none** |
| unfinished requests | **0** |
| `readyState` after a soft reload | `complete`, 75 ms |
| the open tab | kept its own version, as designed |
| a freshly opened tab | **served the new version** |

Updates still reach users; nothing loops.

## Also swept

Two commented-out `console.log` lines, and the unused `IonRouterLink` import behind the last build warning. Lint, 119 tests and the build all pass clean.